### PR TITLE
Normalize CJK markdown emphasis when streaming completes

### DIFF
--- a/src/hooks/__tests__/useChatThread.test.ts
+++ b/src/hooks/__tests__/useChatThread.test.ts
@@ -140,6 +140,26 @@ describe("useChatThread", () => {
     );
   });
 
+  it("normalizes CJK markdown on completion", async () => {
+    const { result } = renderHook(() => useChatThread());
+
+    act(() => {
+      result.current.addMessage({
+        ...mockAIMessage,
+        content: "これは**やりたかったこと。**だからするの",
+      });
+    });
+
+    await act(async () => {
+      result.current.completeLastMessage();
+    });
+
+    expect(result.current.messages[0].content).toBe(
+      "これは**やりたかったこと。** だからするの",
+    );
+    expect(result.current.messages[0].status).toBe("done");
+  });
+
   it("completeLastMessage does not change state for non-AI messages", async () => {
     const { result } = renderHook(() => useChatThread());
 

--- a/src/hooks/useChatThread.ts
+++ b/src/hooks/useChatThread.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Message } from "../types";
 import { chatStorage } from "../utils/chatStorage";
+import { normalizeCjkMarkdown } from "../lib/markdown/cjk-normalize";
 
 export const useChatThread = () => {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -41,6 +42,7 @@ export const useChatThread = () => {
         if (lastMessage.sender === "ai" && lastMessage.status === "streaming") {
           newMessages[newMessages.length - 1] = {
             ...lastMessage,
+            content: normalizeCjkMarkdown(lastMessage.content),
             status: "done",
           };
         }

--- a/src/lib/markdown/__tests__/cjk-normalize.test.ts
+++ b/src/lib/markdown/__tests__/cjk-normalize.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { normalizeCjkMarkdown } from "../cjk-normalize";
+
+describe("normalizeCjkMarkdown", () => {
+  it("fixes a closing delimiter stuck behind CJK punctuation", () => {
+    expect(normalizeCjkMarkdown("**強調。**続き")).toBe("**強調。** 続き");
+  });
+
+  it("fixes an opening delimiter that runs into CJK punctuation", () => {
+    expect(normalizeCjkMarkdown("字**「重要」**です")).toBe(
+      "字 **「重要」** です",
+    );
+  });
+
+  it("fixes a paragraph-internal bold ending with a period", () => {
+    expect(
+      normalizeCjkMarkdown("これは**やりたかったこと。**だからするの"),
+    ).toBe("これは**やりたかったこと。** だからするの");
+  });
+
+  it("leaves a working bold whose closer precedes punctuation untouched", () => {
+    // `**金額**（補足）` already renders; naively spacing it would break it.
+    const input = "利益剰余金**1億円**（補足）";
+    expect(normalizeCjkMarkdown(input)).toBe(input);
+  });
+
+  it("leaves a working bold whose opener follows punctuation untouched", () => {
+    const input = "前置き。**強調**です";
+    expect(normalizeCjkMarkdown(input)).toBe(input);
+  });
+
+  it("does not touch emphasis surrounded by punctuation", () => {
+    const input = "「**重要**」";
+    expect(normalizeCjkMarkdown(input)).toBe(input);
+  });
+
+  it("does not touch a bold that ends the line after punctuation", () => {
+    const input = "以上で**説明は終わり。**";
+    expect(normalizeCjkMarkdown(input)).toBe(input);
+  });
+
+  it("handles single-star emphasis", () => {
+    expect(normalizeCjkMarkdown("これは*斜体。*続き")).toBe(
+      "これは*斜体。* 続き",
+    );
+  });
+
+  it("handles multiple emphasis spans on one line", () => {
+    expect(normalizeCjkMarkdown("**第一。**そして**第二。**おわり")).toBe(
+      "**第一。** そして**第二。** おわり",
+    );
+  });
+
+  it("leaves non-CJK markdown unchanged", () => {
+    const input = "This is **bold**, and so is *this*.";
+    expect(normalizeCjkMarkdown(input)).toBe(input);
+  });
+
+  it("does not touch unpaired delimiters", () => {
+    const input = "掛け算は 2*3 と 4*5。";
+    expect(normalizeCjkMarkdown(input)).toBe(input);
+  });
+
+  it("preserves fenced code blocks verbatim", () => {
+    const input = [
+      "説明します。",
+      "```",
+      "x = **a。**b",
+      "```",
+      "本文**です。**",
+    ].join("\n");
+    expect(normalizeCjkMarkdown(input)).toBe(input);
+  });
+
+  it("preserves inline code spans verbatim", () => {
+    expect(normalizeCjkMarkdown("値は`**a。**b`と表示**する。**確認")).toBe(
+      "値は`**a。**b`と表示**する。** 確認",
+    );
+  });
+
+  it("is idempotent", () => {
+    const once = normalizeCjkMarkdown("**強調。**続き");
+    expect(normalizeCjkMarkdown(once)).toBe(once);
+  });
+});

--- a/src/lib/markdown/cjk-normalize.ts
+++ b/src/lib/markdown/cjk-normalize.ts
@@ -1,0 +1,172 @@
+/**
+ * Deterministically normalizes CJK markdown so that emphasis delimiters
+ * (`*`, `**`, `***`, `_`, `__`, `___`) adjacent to CJK punctuation are parsed
+ * as intended by CommonMark.
+ *
+ * Languages without inter-word spacing (Chinese, Japanese, Korean) frequently
+ * place punctuation directly next to emphasis delimiters. CommonMark decides
+ * whether a delimiter run opens or closes emphasis using its "left-flanking" /
+ * "right-flanking" classification, which depends on the Unicode punctuation
+ * category of the surrounding characters. When a delimiter that is meant to
+ * open is immediately followed by punctuation (and preceded by a regular
+ * character) it cannot be left-flanking; when a delimiter that is meant to
+ * close is immediately preceded by punctuation (and followed by a regular
+ * character) it cannot be right-flanking. In either case the delimiter is
+ * rendered literally instead of producing emphasis. For example:
+ *
+ *   ✗ **強調。**続き        -> closing ** preceded by 。 fails to close
+ *   ✗ 字**「重要」**です     -> both delimiters fail (around 「」)
+ *
+ * The fix is to insert a single space on the outside of the offending
+ * delimiter (before an opener, after a closer) so the run becomes flanking and
+ * the emphasis renders:
+ *
+ *   ○ **強調。** 続き
+ *   ○ 字 **「重要」** です
+ *
+ * Crucially, the same punctuation adjacency that breaks an *opening* delimiter
+ * is harmless for a *closing* one (and vice versa). `cmark-cjk-lint`'s regexes
+ * cannot tell the two roles apart, so blindly inserting spaces for every match
+ * would break emphasis that already renders correctly (e.g. `**金額**（補足）`).
+ * This module therefore pairs the delimiter runs first and only fixes a
+ * delimiter when it genuinely fails the flanking test for the role it plays.
+ */
+
+// Any CJK letter (Hiragana, Katakana, half-width Katakana, CJK ideographs,
+// Hangul). Used to decide whether the document is CJK content at all.
+const CJK_LETTER = /[぀-ヿㇰ-ㇿ㐀-䶿一-鿿豈-﫿ｦ-ﾟ가-힯]/u;
+
+// A maximal run of emphasis delimiter characters (all `*` or all `_`).
+const DELIM_RUN = /\*+|_+/g;
+
+// Fenced code block boundary (``` or ~~~), possibly indented.
+const FENCE = /^\s*(```|~~~)/;
+
+// Inline code span, used to split a line so code is never rewritten.
+const INLINE_CODE = /(`[^`]*`)/;
+
+const UNICODE_PUNCT = /\p{P}/u;
+const WHITESPACE = /\s/;
+
+// Mirrors cmark-cjk-lint: the emphasis delimiters themselves are excluded from
+// the punctuation class so an adjacent delimiter is not treated as punctuation.
+const isPunctuation = (ch: string | undefined): boolean =>
+  ch !== undefined && ch !== "*" && ch !== "_" && UNICODE_PUNCT.test(ch);
+
+// A character that is neither punctuation nor whitespace (e.g. a CJK letter or
+// an ASCII word character). The start/end of a segment counts as whitespace.
+const isWordish = (ch: string | undefined): boolean =>
+  ch !== undefined && !WHITESPACE.test(ch) && !UNICODE_PUNCT.test(ch);
+
+interface Run {
+  start: number;
+  end: number;
+  text: string;
+}
+
+const findRuns = (segment: string): Run[] => {
+  const runs: Run[] = [];
+  DELIM_RUN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = DELIM_RUN.exec(segment)) !== null) {
+    runs.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      text: match[0],
+    });
+  }
+  return runs;
+};
+
+const fixSegment = (segment: string): string => {
+  const runs = findRuns(segment);
+  if (runs.length < 2) {
+    return segment;
+  }
+
+  // Pair runs sharing the same delimiter token (e.g. all `**`) in order:
+  // the first opens, the second closes, and so on. This matches how an LLM
+  // writes balanced emphasis and lets us know each delimiter's role.
+  const groups = new Map<string, Run[]>();
+  for (const run of runs) {
+    const group = groups.get(run.text);
+    if (group) {
+      group.push(run);
+    } else {
+      groups.set(run.text, [run]);
+    }
+  }
+
+  // Positions at which a space must be inserted (immediately before the index).
+  const insertions = new Set<number>();
+  for (const group of groups.values()) {
+    for (let i = 0; i + 1 < group.length; i += 2) {
+      const opener = group[i];
+      const closer = group[i + 1];
+
+      // Opener fails to be left-flanking: regular char before, punctuation
+      // after -> add a space before it.
+      if (
+        isWordish(segment[opener.start - 1]) &&
+        isPunctuation(segment[opener.end])
+      ) {
+        insertions.add(opener.start);
+      }
+
+      // Closer fails to be right-flanking: punctuation before, regular char
+      // after -> add a space after it.
+      if (
+        isPunctuation(segment[closer.start - 1]) &&
+        isWordish(segment[closer.end])
+      ) {
+        insertions.add(closer.end);
+      }
+    }
+  }
+
+  if (insertions.size === 0) {
+    return segment;
+  }
+
+  let result = "";
+  for (let i = 0; i < segment.length; i++) {
+    if (insertions.has(i)) {
+      result += " ";
+    }
+    result += segment[i];
+  }
+  return result;
+};
+
+const fixLine = (line: string): string =>
+  line
+    .split(INLINE_CODE)
+    // Odd indices are inline code spans and are left untouched.
+    .map((part, index) => (index % 2 === 1 ? part : fixSegment(part)))
+    .join("");
+
+/**
+ * Returns a deterministically valid version of the given markdown. Lines inside
+ * fenced code blocks and inline code spans are preserved verbatim. Non-CJK
+ * documents are returned unchanged.
+ */
+export const normalizeCjkMarkdown = (text: string): string => {
+  if (!CJK_LETTER.test(text)) {
+    return text;
+  }
+
+  let insideFence = false;
+  return text
+    .split("\n")
+    .map((line) => {
+      if (FENCE.test(line)) {
+        insideFence = !insideFence;
+        return line;
+      }
+      if (insideFence) {
+        return line;
+      }
+      return fixLine(line);
+    })
+    .join("\n");
+};


### PR DESCRIPTION
## Summary

LLM responses written in Japanese / Chinese / Korean frequently place punctuation directly next to emphasis delimiters, e.g. `**強調。**続き`. Because CommonMark decides whether a delimiter run opens or closes emphasis using its *left-flanking* / *right-flanking* classification — which depends on the Unicode punctuation category of the surrounding characters — these delimiters fail the flanking test and the asterisks are rendered **literally** instead of producing bold/italic text.

This PR adds a deterministic normalizer that runs the moment an AI message finishes streaming, repairing the broken emphasis so it renders as intended.

## Approach

The key subtlety: the *same* punctuation adjacency that breaks an **opening** delimiter is harmless for a **closing** one, and vice versa. A regex that simply mirrors `cmark-cjk-lint`'s detection patterns cannot tell the two roles apart, so blindly inserting spaces for every match would **break** emphasis that already renders correctly (for example `**金額**（補足）`, which CommonMark parses fine).

`normalizeCjkMarkdown` instead:

1. Skips non-CJK documents, fenced code blocks, and inline code spans verbatim.
2. Finds the emphasis delimiter runs in each line and pairs same-token runs in order (opener, closer, opener, closer, …) — matching how balanced emphasis is written.
3. For each pair, checks whether the **opener** is left-flanking and the **closer** is right-flanking, given the actual surrounding characters.
4. Inserts a single space on the *outside* of only the delimiters that genuinely fail their flanking test (before a broken opener, after a broken closer).

This repairs cases like:

| input | output |
| --- | --- |
| `**強調。**続き` | `**強調。** 続き` |
| `字**「重要」**です` | `字 **「重要」** です` |

…while leaving already-valid emphasis (`**金額**（補足）`, `前置き。**強調**です`, `「**重要**」`) completely untouched.

## Where it hooks in

`completeLastMessage()` in `useChatThread` — the single point where a streaming AI message transitions to `done` — normalizes the final content before it is stored and rendered. Streaming chunks are still appended as-is; normalization happens once, deterministically, at completion.

## Verification

All expected outputs were validated against the actual `micromark` parser used by `react-markdown` to confirm they produce `<strong>`/`<em>` and that untouched inputs already did.

- New unit tests: `src/lib/markdown/__tests__/cjk-normalize.test.ts`
- New integration test in `src/hooks/__tests__/useChatThread.test.ts`
- Full suite: 142 tests passing; `tsc --noEmit` clean.