### PR TITLE
Target the OpenAI Responses API with a fixed model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Emerald
 
-AI assistant browser extension with OpenAI integration. Supports Chrome and Firefox.
+AI assistant browser extension built on the OpenAI Responses API. Supports Chrome and Firefox.
 
 ## Features
 
-- Chat with OpenAI GPT models
+- Chat with `gpt-5.6-luna` at `max` reasoning effort
+- Web search through OpenAI's built-in `web_search` tool
 - Screen capture and image analysis
 - Page context integration
 - Conversation history

--- a/docs/architecture/api-communication.md
+++ b/docs/architecture/api-communication.md
@@ -2,7 +2,20 @@
 
 ## Overview
 
-The API communication system is designed around **streaming responses**, **tool execution**, and **modular responsibility separation**. The architecture supports real-time conversation updates while maintaining robust error handling and extensibility.
+The API communication system targets the **OpenAI Responses API** exclusively and
+is designed around **streaming responses**, **tool execution**, and **modular
+responsibility separation**. The architecture supports real-time conversation
+updates while maintaining robust error handling and extensibility.
+
+Fixed configuration lives in `src/lib/openai/constants.ts`:
+
+| Setting          | Value                                 |
+| ---------------- | ------------------------------------- |
+| Endpoint         | `https://api.openai.com/v1/responses` |
+| Model            | `gpt-5.6-luna`                        |
+| Reasoning effort | `max`                                 |
+
+The only user-provided API setting is the OpenAI API key.
 
 ## Architecture Components
 
@@ -30,8 +43,7 @@ The API communication system is designed around **streaming responses**, **tool 
 
 **Key Features**:
 
-- Configuration management (API key, model, base URL)
-- Request payload construction
+- Request payload construction (model, tools, reasoning effort)
 - Stream processing coordination
 - Tool execution integration
 - Error handling and retry logic
@@ -41,9 +53,25 @@ The API communication system is designed around **streaming responses**, **tool 
 ```typescript
 interface OpenAIClient {
   sendMessage(
-    messages: OpenAIMessage[],
+    input: ResponseInputItem[],
     callbacks: StreamCallbacks,
   ): Promise<void>;
+}
+```
+
+**Request Shape**:
+
+```json
+{
+  "model": "gpt-5.6-luna",
+  "input": [{ "role": "user", "content": "..." }],
+  "tools": [
+    { "type": "function", "name": "get_current_time" },
+    { "type": "web_search" }
+  ],
+  "tool_choice": "auto",
+  "reasoning": { "effort": "max" },
+  "stream": true
 }
 ```
 
@@ -55,15 +83,15 @@ interface OpenAIClient {
 
 ### 2. StreamProcessor (`src/lib/openai/stream-processor.ts`)
 
-**Responsibility**: Handles OpenAI streaming response parsing and event emission.
+**Responsibility**: Parses the Responses API server-sent event stream and emits
+application events.
 
-**Key Features**:
+**Handled Events**:
 
-- Real-time chunk processing
-- Tool call accumulation
-- JSON parsing with error recovery
-- Buffer management for partial data
-- Event-driven architecture
+- `response.output_text.delta`: Streamed assistant text
+- `response.output_item.done` with a `function_call` item: A local tool has to run
+- `response.output_item.done` with a `web_search_call` item: Reported as tool activity
+- `error`, `response.failed`, `response.incomplete`: Turned into a `StreamError`
 
 **Processing Flow**:
 
@@ -74,43 +102,48 @@ Raw Stream → Buffer Management → Line Processing → JSON Parsing → Event 
 **State Management**:
 
 - **Buffer**: Accumulates partial stream data
-- **Tool Calls Buffer**: Builds complete tool calls from deltas
+- **Function Calls**: Collected until the stream ends, then handed to the client
 - **Error State**: Handles malformed data gracefully
+
+When the stream ends with pending function calls, `onToolCalls` fires instead of
+`onComplete`: the conversation is not finished until the follow-up request that
+carries the tool outputs has streamed its own answer.
 
 ### 3. ToolExecutor (`src/lib/tools/executor.ts`)
 
-**Responsibility**: Executes Chrome extension tools and manages tool lifecycle.
+**Responsibility**: Executes the local function tools and manages tool lifecycle.
 
-**Current Tools**:
+**Local Tools**:
 
-- `get_page_text`: Extracts and processes page content from active tab
-  - Fetches HTML content from the page
-  - Parses HTML using Defuddle for intelligent content extraction
-  - Converts processed content to Markdown using Turndown
-  - Returns clean, structured text content
 - `get_current_time`: Provides current local date and time
   - Returns current local time in readable format
   - Essential for temporal context in conversations
   - Automatically called at conversation start for time-aware responses
 
+**Hosted Tools**:
+
+- `web_search`: OpenAI's built-in web search. It runs server side, so there is
+  nothing to execute locally; results and `url_citation` annotations come back in
+  the same stream.
+
 **Execution Pattern**:
 
 ```typescript
 // Tool execution is async and error-isolated
-const results = await toolExecutor.execute(toolCalls);
-// Each tool call gets individual error handling
+const outputs = await toolExecutor.execute(functionCalls);
+// Each function call gets individual error handling
 ```
 
 **Error Isolation**: Tool failures don't break the conversation flow.
 
 ### 4. MessageBuilder (`src/lib/message-builder.ts`)
 
-**Responsibility**: Converts application data structures to OpenAI API format.
+**Responsibility**: Converts application data structures to Responses API input items.
 
 **Key Transformations**:
 
-- Conversation history → OpenAI messages
-- Multimodal content (text + images) → structured format
+- Conversation history → input message items
+- Multimodal content (`input_text` + `input_image`) → structured format
 - System prompt injection for new conversations
 - Message role mapping (user/ai → user/assistant)
 
@@ -131,8 +164,14 @@ User Input + Images → MessageBuilder (multimodal format) → OpenAIClient → 
 ### 3. Tool-Enhanced Conversation
 
 ```
-User Input → OpenAI → Tool Call → ToolExecutor → Chrome API →
-Tool Result → OpenAI (follow-up) → StreamProcessor → UI Update
+User Input → OpenAI → function_call → ToolExecutor → Chrome API →
+function_call_output → OpenAI (follow-up) → StreamProcessor → UI Update
+```
+
+### 4. Web Search Conversation
+
+```
+User Input → OpenAI → hosted web search → answer with citations → StreamProcessor → UI Update
 ```
 
 ## Streaming Architecture
@@ -160,7 +199,8 @@ private processBuffer() {
 ```typescript
 interface StreamCallbacks {
   onContent?: (content: string) => void; // Real-time text updates
-  onToolCalls?: (calls: ToolCall[]) => void; // Tool execution trigger
+  onToolCalls?: (calls: FunctionCallItem[]) => void; // Tool execution trigger
+  onToolActivity?: (interactions: ToolInteraction[]) => void; // Tool transcript
   onComplete?: () => void; // Stream completion
   onError?: (error: Error) => void; // Error handling
 }
@@ -171,20 +211,25 @@ interface StreamCallbacks {
 ### 1. Tool Definition
 
 ```typescript
-interface ToolDefinition {
+// Local function tool (flat shape, as required by the Responses API)
+interface FunctionTool {
   type: "function";
-  function: {
-    name: string;
-    description: string;
-    parameters: JSONSchema;
-  };
+  name: string;
+  description: string;
+  parameters: JSONSchema;
+  strict: true;
+}
+
+// Hosted tool
+interface WebSearchTool {
+  type: "web_search";
 }
 ```
 
 ### 2. Execution Pipeline
 
 ```
-OpenAI Tool Request → ToolExecutor.execute() → Chrome API Call → Result → OpenAI
+OpenAI function_call → ToolExecutor.execute() → Chrome API Call → function_call_output → OpenAI
 ```
 
 ### 3. Error Handling in Tools
@@ -238,17 +283,17 @@ OpenAI Tool Request → ToolExecutor.execute() → Chrome API Call → Result �
 ```typescript
 interface OpenAIClientConfig {
   apiKey: string; // Required: OpenAI API authentication
-  model?: string; // Optional: Model selection (default: gpt-5.1)
-  baseUrl?: string; // Optional: Custom API endpoint
 }
 ```
+
+Everything else is fixed: model, endpoint, reasoning effort and tools are
+compiled in, so there is no provider, model or endpoint selection to configure.
 
 ### 2. Runtime Configuration
 
 - API key validation
-- Model capability detection
-- Feature flag management
-- Environment-specific settings
+- System prompt
+- Conversation storage (S3 / MinIO) settings
 
 ## Performance Optimization
 
@@ -272,39 +317,29 @@ interface OpenAIClientConfig {
 
 ## Extensibility Points
 
-### 1. Adding New AI Providers
-
-```typescript
-// Implement common interface
-interface AIClient {
-  sendMessage(messages: Message[], callbacks: StreamCallbacks): Promise<void>;
-}
-
-// Register new provider
-const client = providerFactory.create(providerType, config);
-```
-
-### 2. Adding New Tools
+### 1. Adding New Tools
 
 ```typescript
 // Extend ToolExecutor with new tool
-private async executeSingleTool(toolCall: ToolCall): Promise<ToolResult> {
-  switch (toolCall.function.name) {
+private async executeSingleTool(
+  functionCall: FunctionCallItem,
+): Promise<FunctionCallOutputItem> {
+  switch (functionCall.name) {
     case "new_tool_name":
-      return await this.executeNewTool(toolCall.id);
+      return await this.executeNewTool(functionCall.call_id);
     // ... existing cases
   }
 }
 ```
 
-### 3. Custom Message Formatting
+### 2. Custom Message Formatting
 
 ```typescript
 // Extend MessageBuilder for new content types
 buildMessages(message, history, systemPrompt, contextData) {
   // Handle new context data types
   // Apply custom formatting rules
-  // Return OpenAI-compatible format
+  // Return Responses API input items
 }
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -42,15 +42,19 @@ Emerald follows a **modular, layered architecture** that separates concerns and 
 
 ```
 OpenAIClient
-├── StreamProcessor     # Handles streaming responses
-├── ToolExecutor       # Executes Chrome extension tools
-└── MessageBuilder     # Converts to OpenAI message format
+├── StreamProcessor     # Handles streaming Responses API events
+├── ToolExecutor       # Executes local function tools
+└── MessageBuilder     # Converts to Responses API input items
 ```
+
+The client talks to the OpenAI Responses API only. The model, the endpoint and
+the reasoning effort are fixed in `src/lib/openai/constants.ts`.
 
 #### Tool System (`src/lib/tools/`)
 
-- **ToolExecutor**: Manages Chrome extension tool execution
-- **Available Tools**: Page text extraction, future extensibility
+- **ToolExecutor**: Executes the local function tools
+- **Local Tools**: `get_current_time`
+- **Hosted Tools**: OpenAI's built-in `web_search`, resolved server side
 - **Pattern**: Strategy pattern for tool implementations
 
 ### 4. Type System (`src/types/`)
@@ -115,7 +119,7 @@ const messages = messageBuilder.buildMessages(
 
 ```typescript
 // Different tools can be executed through common interface
-const results = await toolExecutor.execute(toolCalls);
+const results = await toolExecutor.execute(functionCalls);
 ```
 
 ## Error Handling Strategy
@@ -176,15 +180,7 @@ Add new tools by:
 2. Adding tool definition to `AVAILABLE_TOOLS`
 3. Adding tests for new functionality
 
-### 2. New AI Providers
-
-Extend by:
-
-1. Creating new client class implementing common interface
-2. Adding provider selection in configuration
-3. Maintaining consistent message format
-
-### 3. New UI Components
+### 2. New UI Components
 
 Add by:
 

--- a/src/components/ApiKeySettings.tsx
+++ b/src/components/ApiKeySettings.tsx
@@ -10,35 +10,15 @@ import {
   Divider,
   FormControlLabel,
   Switch,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemText,
-  Stack,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
 } from "@mui/material";
-import { Visibility, VisibilityOff, Delete } from "@mui/icons-material";
-import { useSettings, type Profile } from "../hooks/useSettings";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
+import { useSettings } from "../hooks/useSettings";
+import { MODEL, REASONING_EFFORT } from "../lib/openai/constants";
 
 const ApiKeySettings: React.FC = () => {
-  const {
-    settings,
-    profiles,
-    loading,
-    saveSettings,
-    saveProfile,
-    applyProfile,
-    deleteProfile,
-  } = useSettings();
+  const { settings, loading, saveSettings } = useSettings();
   const [apiKey, setApiKey] = useState(settings.openaiApiKey);
   const [systemPrompt, setSystemPrompt] = useState(settings.systemPrompt);
-  const [baseUrl, setBaseUrl] = useState(settings.baseUrl);
-  const [model, setModel] = useState(settings.model);
-  const [braveApiKey, setBraveApiKey] = useState(settings.braveApiKey);
   const [showApiKey, setShowApiKey] = useState(false);
   const [s3Endpoint, setS3Endpoint] = useState(settings.s3Endpoint);
   const [s3Region, setS3Region] = useState(settings.s3Region);
@@ -58,9 +38,6 @@ const ApiKeySettings: React.FC = () => {
     if (loading) return;
     setApiKey(settings.openaiApiKey);
     setSystemPrompt(settings.systemPrompt);
-    setBaseUrl(settings.baseUrl);
-    setModel(settings.model);
-    setBraveApiKey(settings.braveApiKey);
     setS3Endpoint(settings.s3Endpoint);
     setS3Region(settings.s3Region);
     setS3Bucket(settings.s3Bucket);
@@ -70,25 +47,9 @@ const ApiKeySettings: React.FC = () => {
     setS3Prefix(settings.s3Prefix);
     setS3PublicBaseUrl(settings.s3PublicBaseUrl);
   }, [loading, settings]);
-  const [showBraveApiKey, setShowBraveApiKey] = useState(false);
-  const [profileName, setProfileName] = useState("");
-  const [profileToApply, setProfileToApply] = useState<Profile | null>(null);
   const [saveStatus, setSaveStatus] = useState<
     "idle" | "saving" | "success" | "error"
   >("idle");
-
-  const handleSaveProfile = async () => {
-    const name = profileName.trim();
-    if (!name) return;
-    await saveProfile(name, { baseUrl, openaiApiKey: apiKey, model });
-    setProfileName("");
-  };
-
-  const handleConfirmApply = async () => {
-    if (!profileToApply) return;
-    await applyProfile(profileToApply.id);
-    setProfileToApply(null);
-  };
 
   const handleSave = async () => {
     setSaveStatus("saving");
@@ -96,9 +57,6 @@ const ApiKeySettings: React.FC = () => {
       await saveSettings({
         openaiApiKey: apiKey,
         systemPrompt,
-        baseUrl,
-        model,
-        braveApiKey,
         s3Endpoint,
         s3Region,
         s3Bucket,
@@ -129,14 +87,14 @@ const ApiKeySettings: React.FC = () => {
 
       <TextField
         fullWidth
-        label="API Key"
+        label="OpenAI API Key"
         type={showApiKey ? "text" : "password"}
         value={apiKey}
         onChange={(e) => setApiKey(e.target.value)}
         placeholder="sk-..."
         margin="normal"
         error={apiKey.length > 0 && !isValidApiKey(apiKey)}
-        helperText="API key for OpenAI, OpenRouter, or any compatible provider"
+        helperText="API key for the OpenAI Responses API"
         InputProps={{
           endAdornment: (
             <InputAdornment position="end">
@@ -152,138 +110,10 @@ const ApiKeySettings: React.FC = () => {
         }}
       />
 
-      <TextField
-        fullWidth
-        label="Base URL"
-        value={baseUrl}
-        onChange={(e) => setBaseUrl(e.target.value)}
-        placeholder="https://api.openai.com/v1/chat/completions"
-        margin="normal"
-        helperText="Chat Completions endpoint. e.g. OpenRouter: https://openrouter.ai/api/v1/chat/completions"
-      />
-
-      <TextField
-        fullWidth
-        label="Model"
-        value={model}
-        onChange={(e) => setModel(e.target.value)}
-        placeholder="gpt-5.4"
-        margin="normal"
-        helperText="Model ID. e.g. OpenRouter: anthropic/claude-opus-4.1"
-      />
-
-      <Box
-        sx={{
-          mt: 1,
-          mb: 1,
-          p: 1.5,
-          border: 1,
-          borderColor: "divider",
-          borderRadius: 1,
-        }}
-      >
-        <Typography variant="subtitle2" gutterBottom>
-          Provider Profiles
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-          Save the current Base URL, API Key and Model as a named profile, then
-          switch providers with one click.
-        </Typography>
-
-        <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
-          <TextField
-            size="small"
-            fullWidth
-            label="Profile name"
-            value={profileName}
-            onChange={(e) => setProfileName(e.target.value)}
-            placeholder="e.g. OpenRouter Claude"
-          />
-          <Button
-            variant="outlined"
-            onClick={handleSaveProfile}
-            disabled={!profileName.trim() || !baseUrl.trim() || !model.trim()}
-          >
-            Save
-          </Button>
-        </Stack>
-
-        {profiles.length > 0 && (
-          <List dense disablePadding>
-            {profiles.map((profile) => (
-              <ListItem
-                key={profile.id}
-                disableGutters
-                disablePadding
-                secondaryAction={
-                  <IconButton
-                    edge="end"
-                    aria-label={`delete profile ${profile.name}`}
-                    onClick={() => deleteProfile(profile.id)}
-                  >
-                    <Delete fontSize="small" />
-                  </IconButton>
-                }
-              >
-                <ListItemButton
-                  onClick={() => setProfileToApply(profile)}
-                  sx={{ borderRadius: 1 }}
-                >
-                  <ListItemText
-                    primary={profile.name}
-                    secondary={profile.model}
-                    primaryTypographyProps={{ noWrap: true }}
-                    secondaryTypographyProps={{ noWrap: true }}
-                  />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
-        )}
-      </Box>
-
-      <Dialog
-        open={profileToApply !== null}
-        onClose={() => setProfileToApply(null)}
-      >
-        <DialogTitle>Apply profile?</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Switch the Base URL, API Key and Model to
-            {profileToApply ? ` "${profileToApply.name}"` : ""}?
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setProfileToApply(null)}>Cancel</Button>
-          <Button onClick={handleConfirmApply} variant="contained">
-            Apply
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      <TextField
-        fullWidth
-        label="Brave Search API Key (optional)"
-        type={showBraveApiKey ? "text" : "password"}
-        value={braveApiKey}
-        onChange={(e) => setBraveApiKey(e.target.value)}
-        placeholder="BSA..."
-        margin="normal"
-        helperText="Set to enable web search. The AI looks things up when needed and cites source URLs."
-        InputProps={{
-          endAdornment: (
-            <InputAdornment position="end">
-              <IconButton
-                aria-label="toggle brave api key visibility"
-                onClick={() => setShowBraveApiKey(!showBraveApiKey)}
-                edge="end"
-              >
-                {showBraveApiKey ? <VisibilityOff /> : <Visibility />}
-              </IconButton>
-            </InputAdornment>
-          ),
-        }}
-      />
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+        Model: {MODEL} (reasoning effort: {REASONING_EFFORT}). Web search is
+        handled by the built-in OpenAI tool.
+      </Typography>
 
       <TextField
         fullWidth
@@ -404,8 +234,6 @@ const ApiKeySettings: React.FC = () => {
           !apiKey ||
           !isValidApiKey(apiKey) ||
           !systemPrompt.trim() ||
-          !baseUrl.trim() ||
-          !model.trim() ||
           saveStatus === "saving"
         }
         sx={{ mt: 2 }}

--- a/src/hooks/__tests__/useApi.test.ts
+++ b/src/hooks/__tests__/useApi.test.ts
@@ -9,9 +9,6 @@ vi.mock("../useSettings", () => ({
     settings: {
       openaiApiKey: "sk-test-key-123",
       systemPrompt: "You are a helpful AI assistant for testing.",
-      baseUrl: "https://api.openai.com/v1/chat/completions",
-      model: "gpt-5.4",
-      braveApiKey: "",
     },
     loading: false,
     updateApiKey: vi.fn(),
@@ -114,9 +111,6 @@ describe("useApi", () => {
 
     expect(OpenAIClient).toHaveBeenCalledWith({
       apiKey: "sk-test-key-123",
-      baseUrl: "https://api.openai.com/v1/chat/completions",
-      model: "gpt-5.4",
-      braveApiKey: "",
     });
 
     expect(MessageBuilder).toHaveBeenCalled();

--- a/src/hooks/__tests__/useSettings.test.ts
+++ b/src/hooks/__tests__/useSettings.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useSettings } from "../useSettings";
 import { chromeMock } from "../../test/mocks/chrome";
 
-describe("useSettings profiles", () => {
+describe("useSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(chromeMock.storage.local.get).mockResolvedValue({});
@@ -16,111 +16,50 @@ describe("useSettings profiles", () => {
     });
   };
 
-  it("loads profiles from storage on mount", async () => {
-    const stored = [
-      {
-        id: "p1",
-        name: "OpenRouter",
-        baseUrl: "https://openrouter.ai/api/v1/chat/completions",
-        openaiApiKey: "sk-or",
-        model: "anthropic/claude-opus-4.1",
-      },
-    ];
+  it("falls back to the defaults when nothing is stored", async () => {
+    const { result } = renderHook(() => useSettings());
+    await waitLoaded(result);
+
+    expect(result.current.settings.openaiApiKey).toBe("");
+    expect(result.current.settings.systemPrompt).toContain("Emerald");
+    expect(result.current.settings.s3Region).toBe("us-east-1");
+  });
+
+  it("merges stored settings over the defaults", async () => {
     vi.mocked(chromeMock.storage.local.get).mockResolvedValueOnce({
-      llmProfiles: stored,
+      settings: { openaiApiKey: "sk-stored", s3Bucket: "my-bucket" },
     });
 
     const { result } = renderHook(() => useSettings());
     await waitLoaded(result);
 
-    expect(result.current.profiles).toEqual(stored);
+    expect(result.current.settings.openaiApiKey).toBe("sk-stored");
+    expect(result.current.settings.s3Bucket).toBe("my-bucket");
+    expect(result.current.settings.s3Region).toBe("us-east-1");
   });
 
-  it("saves the current provider config as a named profile", async () => {
+  it("persists updated settings to storage", async () => {
     const { result } = renderHook(() => useSettings());
     await waitLoaded(result);
 
     await act(async () => {
-      await result.current.saveProfile("My Provider", {
-        baseUrl: "https://example.com/v1/chat/completions",
-        openaiApiKey: "sk-123",
-        model: "gpt-5.4",
-      });
+      await result.current.updateApiKey("sk-new");
     });
 
-    expect(result.current.profiles).toHaveLength(1);
-    const profile = result.current.profiles[0];
-    expect(profile).toMatchObject({
-      name: "My Provider",
-      baseUrl: "https://example.com/v1/chat/completions",
-      openaiApiKey: "sk-123",
-      model: "gpt-5.4",
-    });
-    expect(profile.id).toBeTruthy();
+    expect(result.current.settings.openaiApiKey).toBe("sk-new");
     expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
-      llmProfiles: [profile],
+      settings: expect.objectContaining({ openaiApiKey: "sk-new" }),
     });
   });
 
-  it("applies a profile into the active settings", async () => {
-    const stored = [
-      {
-        id: "p1",
-        name: "OpenRouter",
-        baseUrl: "https://openrouter.ai/api/v1/chat/completions",
-        openaiApiKey: "sk-or",
-        model: "anthropic/claude-opus-4.1",
-      },
-    ];
-    vi.mocked(chromeMock.storage.local.get).mockResolvedValueOnce({
-      llmProfiles: stored,
-    });
-
+  it("updates the system prompt", async () => {
     const { result } = renderHook(() => useSettings());
     await waitLoaded(result);
 
     await act(async () => {
-      await result.current.applyProfile("p1");
+      await result.current.updateSystemPrompt("Be terse.");
     });
 
-    expect(result.current.settings.baseUrl).toBe(
-      "https://openrouter.ai/api/v1/chat/completions",
-    );
-    expect(result.current.settings.openaiApiKey).toBe("sk-or");
-    expect(result.current.settings.model).toBe("anthropic/claude-opus-4.1");
-  });
-
-  it("does nothing when applying an unknown profile id", async () => {
-    const { result } = renderHook(() => useSettings());
-    await waitLoaded(result);
-
-    const before = result.current.settings;
-    await act(async () => {
-      await result.current.applyProfile("missing");
-    });
-
-    expect(result.current.settings).toEqual(before);
-  });
-
-  it("deletes a profile by id", async () => {
-    const stored = [
-      { id: "p1", name: "A", baseUrl: "u1", openaiApiKey: "k1", model: "m1" },
-      { id: "p2", name: "B", baseUrl: "u2", openaiApiKey: "k2", model: "m2" },
-    ];
-    vi.mocked(chromeMock.storage.local.get).mockResolvedValueOnce({
-      llmProfiles: stored,
-    });
-
-    const { result } = renderHook(() => useSettings());
-    await waitLoaded(result);
-
-    await act(async () => {
-      await result.current.deleteProfile("p1");
-    });
-
-    expect(result.current.profiles).toEqual([stored[1]]);
-    expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
-      llmProfiles: [stored[1]],
-    });
+    expect(result.current.settings.systemPrompt).toBe("Be terse.");
   });
 });

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -36,9 +36,6 @@ export const useApi = () => {
 
       const client = new OpenAIClient({
         apiKey: settings.openaiApiKey,
-        baseUrl: settings.baseUrl,
-        model: settings.model,
-        braveApiKey: settings.braveApiKey,
       });
 
       const messageBuilder = new MessageBuilder();

--- a/src/hooks/useConversationExport.ts
+++ b/src/hooks/useConversationExport.ts
@@ -50,11 +50,7 @@ export const useConversationExport = () => {
 
     try {
       const title = await generateConversationTitle(
-        {
-          apiKey: settings.openaiApiKey,
-          model: settings.model,
-          baseUrl: settings.baseUrl,
-        },
+        { apiKey: settings.openaiApiKey },
         messages,
       );
       const html = buildConversationHtml(messages, {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -3,9 +3,6 @@ import { useState, useEffect } from "react";
 interface Settings {
   openaiApiKey: string;
   systemPrompt: string;
-  baseUrl: string;
-  model: string;
-  braveApiKey: string;
   s3Endpoint: string;
   s3Region: string;
   s3Bucket: string;
@@ -16,21 +13,10 @@ interface Settings {
   s3PublicBaseUrl: string;
 }
 
-interface Profile {
-  id: string;
-  name: string;
-  baseUrl: string;
-  openaiApiKey: string;
-  model: string;
-}
-
 const DEFAULT_SETTINGS: Settings = {
   openaiApiKey: "",
   systemPrompt:
-    "You are a helpful AI assistant integrated into a Chrome extension called Emerald. You can help users with various tasks while they browse the web. When users provide page content, use it to give more contextual and relevant responses. Be concise but helpful, and adapt your responses to the context of what the user is doing.",
-  baseUrl: "https://api.openai.com/v1/chat/completions",
-  model: "gpt-5.4",
-  braveApiKey: "",
+    "You are a helpful AI assistant integrated into a Chrome extension called Emerald. You can help users with various tasks while they browse the web. When users provide page content, use it to give more contextual and relevant responses. Use the built-in web search tool whenever up-to-date or external information would help, and cite the source URLs as Markdown links. Be concise but helpful, and adapt your responses to the context of what the user is doing.",
   s3Endpoint: "",
   s3Region: "us-east-1",
   s3Bucket: "",
@@ -41,13 +27,10 @@ const DEFAULT_SETTINGS: Settings = {
   s3PublicBaseUrl: "",
 };
 
-export type { Settings, Profile };
-
-const PROFILES_KEY = "llmProfiles";
+export type { Settings };
 
 export const useSettings = () => {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
-  const [profiles, setProfiles] = useState<Profile[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -56,12 +39,9 @@ export const useSettings = () => {
 
   const loadSettings = async () => {
     try {
-      const result = await chrome.storage.local.get(["settings", PROFILES_KEY]);
+      const result = await chrome.storage.local.get(["settings"]);
       if (result.settings) {
         setSettings({ ...DEFAULT_SETTINGS, ...result.settings });
-      }
-      if (Array.isArray(result[PROFILES_KEY])) {
-        setProfiles(result[PROFILES_KEY]);
       }
     } catch (error) {
       console.error("Failed to load settings:", error);
@@ -73,7 +53,6 @@ export const useSettings = () => {
   const saveSettings = async (newSettings: Partial<Settings>) => {
     try {
       const updatedSettings = { ...settings, ...newSettings };
-      console.log("Saving settings:", updatedSettings);
       await chrome.storage.local.set({ settings: updatedSettings });
       setSettings(updatedSettings);
     } catch (error) {
@@ -89,52 +68,11 @@ export const useSettings = () => {
     await saveSettings({ systemPrompt });
   };
 
-  const persistProfiles = async (newProfiles: Profile[]) => {
-    try {
-      await chrome.storage.local.set({ [PROFILES_KEY]: newProfiles });
-      setProfiles(newProfiles);
-    } catch (error) {
-      console.error("Failed to save profiles:", error);
-    }
-  };
-
-  const saveProfile = async (
-    name: string,
-    config: Pick<Settings, "baseUrl" | "openaiApiKey" | "model">,
-  ) => {
-    const profile: Profile = {
-      id: crypto.randomUUID(),
-      name,
-      baseUrl: config.baseUrl,
-      openaiApiKey: config.openaiApiKey,
-      model: config.model,
-    };
-    await persistProfiles([...profiles, profile]);
-  };
-
-  const applyProfile = async (id: string) => {
-    const profile = profiles.find((p) => p.id === id);
-    if (!profile) return;
-    await saveSettings({
-      baseUrl: profile.baseUrl,
-      openaiApiKey: profile.openaiApiKey,
-      model: profile.model,
-    });
-  };
-
-  const deleteProfile = async (id: string) => {
-    await persistProfiles(profiles.filter((p) => p.id !== id));
-  };
-
   return {
     settings,
-    profiles,
     loading,
     updateApiKey,
     updateSystemPrompt,
     saveSettings,
-    saveProfile,
-    applyProfile,
-    deleteProfile,
   };
 };

--- a/src/lib/__tests__/message-builder.test.ts
+++ b/src/lib/__tests__/message-builder.test.ts
@@ -122,14 +122,12 @@ describe("MessageBuilder", () => {
           role: "user",
           content: [
             {
-              type: "text",
+              type: "input_text",
               text: "What's in this image?",
             },
             {
-              type: "image_url",
-              image_url: {
-                url: "data:image/png;base64,abc123",
-              },
+              type: "input_image",
+              image_url: "data:image/png;base64,abc123",
             },
           ],
         },
@@ -160,20 +158,16 @@ describe("MessageBuilder", () => {
           role: "user",
           content: [
             {
-              type: "text",
+              type: "input_text",
               text: "Compare these images",
             },
             {
-              type: "image_url",
-              image_url: {
-                url: "data:image/png;base64,abc123",
-              },
+              type: "input_image",
+              image_url: "data:image/png;base64,abc123",
             },
             {
-              type: "image_url",
-              image_url: {
-                url: "data:image/jpeg;base64,def456",
-              },
+              type: "input_image",
+              image_url: "data:image/jpeg;base64,def456",
             },
           ],
         },
@@ -209,14 +203,12 @@ describe("MessageBuilder", () => {
           role: "user",
           content: [
             {
-              type: "text",
+              type: "input_text",
               text: "Look at this",
             },
             {
-              type: "image_url",
-              image_url: {
-                url: "data:image/png;base64,xyz789",
-              },
+              type: "input_image",
+              image_url: "data:image/png;base64,xyz789",
             },
           ],
         },
@@ -387,14 +379,12 @@ describe("MessageBuilder", () => {
           role: "user",
           content: [
             {
-              type: "text",
+              type: "input_text",
               text: `<page_context>\nTitle: Test Page\nURL: https://example.com\n\n# Hello\n</page_context>\n\nLook at this page`,
             },
             {
-              type: "image_url",
-              image_url: {
-                url: "data:image/png;base64,abc123",
-              },
+              type: "input_image",
+              image_url: "data:image/png;base64,abc123",
             },
           ],
         },
@@ -446,14 +436,12 @@ describe("MessageBuilder", () => {
           role: "user",
           content: [
             {
-              type: "text",
+              type: "input_text",
               text: "First message",
             },
             {
-              type: "image_url",
-              image_url: {
-                url: "data:image/png;base64,hist123",
-              },
+              type: "input_image",
+              image_url: "data:image/png;base64,hist123",
             },
           ],
         },
@@ -465,14 +453,12 @@ describe("MessageBuilder", () => {
           role: "user",
           content: [
             {
-              type: "text",
+              type: "input_text",
               text: "Current message",
             },
             {
-              type: "image_url",
-              image_url: {
-                url: "data:image/jpeg;base64,curr456",
-              },
+              type: "input_image",
+              image_url: "data:image/jpeg;base64,curr456",
             },
           ],
         },

--- a/src/lib/message-builder.ts
+++ b/src/lib/message-builder.ts
@@ -1,5 +1,9 @@
 import { Message, ImageData, PageContent } from "../types";
-import { OpenAIMessage, OpenAIMessageContent } from "../types/openai";
+import {
+  ResponseContentPart,
+  ResponseInputItem,
+  ResponseMessageItem,
+} from "../types/openai";
 
 export class MessageBuilder {
   buildMessages(
@@ -8,8 +12,8 @@ export class MessageBuilder {
     systemPrompt?: string,
     contextImages?: ImageData[],
     contextPageContent?: PageContent,
-  ): OpenAIMessage[] {
-    const messages: OpenAIMessage[] = [];
+  ): ResponseInputItem[] {
+    const messages: ResponseInputItem[] = [];
 
     if (conversationHistory.length === 0 && systemPrompt) {
       messages.push({
@@ -31,8 +35,10 @@ export class MessageBuilder {
     return messages;
   }
 
-  private convertConversationHistory(history: Message[]): OpenAIMessage[] {
-    return history.map((msg): OpenAIMessage => {
+  private convertConversationHistory(
+    history: Message[],
+  ): ResponseMessageItem[] {
+    return history.map((msg): ResponseMessageItem => {
       let text = msg.content;
       if (msg.sender === "user" && msg.pageContent) {
         const content =
@@ -60,7 +66,7 @@ export class MessageBuilder {
     message: string,
     contextImages?: ImageData[],
     pageContent?: PageContent,
-  ): OpenAIMessage {
+  ): ResponseMessageItem {
     let text = message;
     if (pageContent) {
       const content =
@@ -86,13 +92,13 @@ export class MessageBuilder {
   private buildMultimodalContent(
     text: string,
     images: ImageData[],
-  ): OpenAIMessageContent[] {
-    const content: OpenAIMessageContent[] = [{ type: "text", text }];
+  ): ResponseContentPart[] {
+    const content: ResponseContentPart[] = [{ type: "input_text", text }];
 
     images.forEach((image) => {
       content.push({
-        type: "image_url",
-        image_url: { url: image.dataUrl },
+        type: "input_image",
+        image_url: image.dataUrl,
       });
     });
 

--- a/src/lib/openai/__tests__/client.test.ts
+++ b/src/lib/openai/__tests__/client.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { OpenAIClient } from "../client";
-import { OpenAIMessage, ApiError } from "../../../types/openai";
-
-vi.mock("../stream-processor");
-vi.mock("../tools/executor");
+import { ResponseInputItem, ApiError } from "../../../types/openai";
 
 const createMockReader = (chunks: string[]) => {
   let index = 0;
@@ -28,6 +25,12 @@ const createMockResponse = (chunks: string[], status = 200) => ({
   },
 });
 
+const textDelta = (text: string) =>
+  `data: {"type":"response.output_text.delta","delta":${JSON.stringify(text)}}\n`;
+
+const functionCallDone = (callId: string, name: string, args: string) =>
+  `data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"${callId}","name":"${name}","arguments":${JSON.stringify(args)}}}\n`;
+
 describe("OpenAIClient", () => {
   let client: OpenAIClient;
   const mockApiKey = "sk-test-key-123";
@@ -37,31 +40,8 @@ describe("OpenAIClient", () => {
     vi.clearAllMocks();
   });
 
-  describe("constructor", () => {
-    it("should initialize with default config", () => {
-      const client = new OpenAIClient({ apiKey: mockApiKey });
-      expect(client).toBeInstanceOf(OpenAIClient);
-    });
-
-    it("should allow custom model", () => {
-      const client = new OpenAIClient({
-        apiKey: mockApiKey,
-        model: "gpt-4o",
-      });
-      expect(client).toBeInstanceOf(OpenAIClient);
-    });
-
-    it("should allow custom base URL", () => {
-      const client = new OpenAIClient({
-        apiKey: mockApiKey,
-        baseUrl: "https://custom.api.com/v1/chat/completions",
-      });
-      expect(client).toBeInstanceOf(OpenAIClient);
-    });
-  });
-
   describe("sendMessage", () => {
-    const mockMessages: OpenAIMessage[] = [
+    const mockInput: ResponseInputItem[] = [
       {
         role: "user",
         content: "Hello, AI!",
@@ -70,9 +50,9 @@ describe("OpenAIClient", () => {
 
     it("should send message successfully", async () => {
       const chunks = [
-        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
-        'data: {"choices":[{"delta":{"content":" World"}}]}\n',
-        "data: [DONE]\n",
+        textDelta("Hello"),
+        textDelta(" World"),
+        'data: {"type":"response.completed"}\n',
       ];
 
       globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse(chunks));
@@ -80,13 +60,10 @@ describe("OpenAIClient", () => {
       const onContent = vi.fn();
       const onComplete = vi.fn();
 
-      await client.sendMessage(mockMessages, {
-        onContent,
-        onComplete,
-      });
+      await client.sendMessage(mockInput, { onContent, onComplete });
 
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "https://api.openai.com/v1/chat/completions",
+        "https://api.openai.com/v1/responses",
         expect.objectContaining({
           method: "POST",
           headers: {
@@ -96,186 +73,132 @@ describe("OpenAIClient", () => {
         }),
       );
 
+      expect(onContent).toHaveBeenNthCalledWith(1, "Hello");
+      expect(onContent).toHaveBeenNthCalledWith(2, " World");
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    it("should always request gpt-5.6-luna with max reasoning effort", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(createMockResponse([textDelta("test")]));
+
+      await client.sendMessage(mockInput, {});
+
       const requestBody = JSON.parse(
         (globalThis.fetch as any).mock.calls[0][1].body,
       );
-      expect(requestBody.model).toBe("gpt-5.4");
-      expect(requestBody.messages).toEqual(mockMessages);
-      expect(requestBody.tools).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: "function",
-            function: expect.objectContaining({
-              name: "get_current_time",
-            }),
-          }),
-        ]),
-      );
+
+      expect(requestBody.model).toBe("gpt-5.6-luna");
+      expect(requestBody.reasoning).toEqual({ effort: "max" });
+      expect(requestBody.input).toEqual(mockInput);
       expect(requestBody.tool_choice).toBe("auto");
       expect(requestBody.stream).toBe(true);
+    });
+
+    it("should offer the local function tool and the built-in web search", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(createMockResponse([textDelta("test")]));
+
+      await client.sendMessage(mockInput, {});
+
+      const requestBody = JSON.parse(
+        (globalThis.fetch as any).mock.calls[0][1].body,
+      );
+
+      expect(requestBody.tools).toEqual([
+        expect.objectContaining({ type: "function", name: "get_current_time" }),
+        { type: "web_search" },
+      ]);
     });
 
     it("should handle HTTP errors", async () => {
       globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse([], 500));
 
-      await expect(client.sendMessage(mockMessages, {})).rejects.toThrow(
-        ApiError,
-      );
+      await expect(client.sendMessage(mockInput, {})).rejects.toThrow(ApiError);
     });
 
     it("should handle network errors", async () => {
       globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
 
-      await expect(client.sendMessage(mockMessages, {})).rejects.toThrow(
-        ApiError,
-      );
+      await expect(client.sendMessage(mockInput, {})).rejects.toThrow(ApiError);
     });
 
-    it("should handle fetch rejection", async () => {
+    it("should execute function calls and continue with their outputs", async () => {
+      const firstResponse = createMockResponse([
+        functionCallDone("call_1", "get_current_time", "{}"),
+        'data: {"type":"response.completed"}\n',
+      ]);
+      const secondResponse = createMockResponse([
+        textDelta("It is late."),
+        'data: {"type":"response.completed"}\n',
+      ]);
+
       globalThis.fetch = vi
         .fn()
-        .mockRejectedValue(new Error("Connection failed"));
+        .mockResolvedValueOnce(firstResponse)
+        .mockResolvedValueOnce(secondResponse);
 
-      const onError = vi.fn();
+      const onContent = vi.fn();
+      const onComplete = vi.fn();
+      const onToolActivity = vi.fn();
 
-      await expect(
-        client.sendMessage(mockMessages, { onError }),
-      ).rejects.toThrow(ApiError);
-    });
-
-    it("should use custom model when provided", async () => {
-      const customClient = new OpenAIClient({
-        apiKey: mockApiKey,
-        model: "gpt-4o",
+      await client.sendMessage(mockInput, {
+        onContent,
+        onComplete,
+        onToolActivity,
       });
 
-      const chunks = ['data: {"choices":[{"delta":{"content":"test"}}]}\n'];
-      globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse(chunks));
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
 
-      await customClient.sendMessage(mockMessages, {});
-
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          body: expect.stringContaining('"model":"gpt-4o"'),
-        }),
+      const followUpBody = JSON.parse(
+        (globalThis.fetch as any).mock.calls[1][1].body,
       );
+      expect(followUpBody.input).toEqual([
+        ...mockInput,
+        {
+          type: "function_call",
+          call_id: "call_1",
+          name: "get_current_time",
+          arguments: "{}",
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: expect.stringMatching(/^Current local time:/),
+        },
+      ]);
+
+      expect(onToolActivity).toHaveBeenCalledWith([
+        expect.objectContaining({ name: "get_current_time" }),
+      ]);
+      expect(onContent).toHaveBeenCalledWith("It is late.");
+      expect(onComplete).toHaveBeenCalledTimes(1);
     });
 
-    it("should use custom base URL when provided", async () => {
-      const customBaseUrl = "https://custom.api.com/v1/chat/completions";
-      const customClient = new OpenAIClient({
-        apiKey: mockApiKey,
-        baseUrl: customBaseUrl,
-      });
-
-      const chunks = ['data: {"choices":[{"delta":{"content":"test"}}]}\n'];
-      globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse(chunks));
-
-      await customClient.sendMessage(mockMessages, {});
-
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        customBaseUrl,
-        expect.any(Object),
-      );
-    });
-
-    it("should include tools in request", async () => {
-      const chunks = ['data: {"choices":[{"delta":{"content":"test"}}]}\n'];
-      globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse(chunks));
-
-      await client.sendMessage(mockMessages, {});
-
-      const requestBody = JSON.parse(
-        (globalThis.fetch as any).mock.calls[0][1].body,
-      );
-
-      expect(requestBody.tools).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: "function",
-            function: expect.objectContaining({
-              name: "get_current_time",
-            }),
-          }),
-        ]),
-      );
-    });
-
-    it("should set stream to true", async () => {
-      const chunks = ['data: {"choices":[{"delta":{"content":"test"}}]}\n'];
-      globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse(chunks));
-
-      await client.sendMessage(mockMessages, {});
-
-      const requestBody = JSON.parse(
-        (globalThis.fetch as any).mock.calls[0][1].body,
-      );
-
-      expect(requestBody.stream).toBe(true);
-    });
-
-    it("should set tool_choice to auto", async () => {
-      const chunks = ['data: {"choices":[{"delta":{"content":"test"}}]}\n'];
-      globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse(chunks));
-
-      await client.sendMessage(mockMessages, {});
-
-      const requestBody = JSON.parse(
-        (globalThis.fetch as any).mock.calls[0][1].body,
-      );
-
-      expect(requestBody.tool_choice).toBe("auto");
-    });
-
-    it("should handle multiple messages", async () => {
-      const multipleMessages: OpenAIMessage[] = [
-        { role: "system", content: "You are a helpful assistant." },
-        { role: "user", content: "Hello!" },
-        { role: "assistant", content: "Hi there!" },
-        { role: "user", content: "How are you?" },
-      ];
-
-      const chunks = [
-        'data: {"choices":[{"delta":{"content":"I\'m good"}}]}\n',
-      ];
-      globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse(chunks));
-
-      await client.sendMessage(multipleMessages, {});
-
-      const requestBody = JSON.parse(
-        (globalThis.fetch as any).mock.calls[0][1].body,
-      );
-
-      expect(requestBody.messages).toEqual(multipleMessages);
-    });
-
-    it("should handle multimodal messages", async () => {
-      const multimodalMessage: OpenAIMessage[] = [
+    it("should handle multimodal input", async () => {
+      const multimodalInput: ResponseInputItem[] = [
         {
           role: "user",
           content: [
-            { type: "text", text: "What's in this image?" },
-            {
-              type: "image_url",
-              image_url: { url: "data:image/jpeg;base64,..." },
-            },
+            { type: "input_text", text: "What's in this image?" },
+            { type: "input_image", image_url: "data:image/jpeg;base64,..." },
           ],
         },
       ];
 
-      const chunks = [
-        'data: {"choices":[{"delta":{"content":"I see an image"}}]}\n',
-      ];
-      globalThis.fetch = vi.fn().mockResolvedValue(createMockResponse(chunks));
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(createMockResponse([textDelta("I see an image")]));
 
-      await client.sendMessage(multimodalMessage, {});
+      await client.sendMessage(multimodalInput, {});
 
       const requestBody = JSON.parse(
         (globalThis.fetch as any).mock.calls[0][1].body,
       );
 
-      expect(requestBody.messages).toEqual(multimodalMessage);
+      expect(requestBody.input).toEqual(multimodalInput);
     });
   });
 });

--- a/src/lib/openai/__tests__/stream-processor.test.ts
+++ b/src/lib/openai/__tests__/stream-processor.test.ts
@@ -16,10 +16,16 @@ const createMockReader = (chunks: string[]) => {
   };
 };
 
-const createMockResponse = (chunks: string[], hasBody = true) => ({
-  ok: true,
-  body: hasBody ? { getReader: () => createMockReader(chunks) } : null,
-});
+const createMockResponse = (chunks: string[], hasBody = true) =>
+  ({
+    ok: true,
+    body: hasBody ? { getReader: () => createMockReader(chunks) } : null,
+  }) as Response;
+
+const textDelta = (text: string) =>
+  `data: {"type":"response.output_text.delta","delta":${JSON.stringify(text)}}\n`;
+
+const completed = 'data: {"type":"response.completed"}\n';
 
 describe("StreamProcessor", () => {
   let streamProcessor: StreamProcessor;
@@ -30,35 +36,29 @@ describe("StreamProcessor", () => {
   });
 
   describe("processStream", () => {
-    it("should process content messages correctly", async () => {
-      const chunks = [
-        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
-        'data: {"choices":[{"delta":{"content":" World"}}]}\n',
-        "data: [DONE]\n",
-      ];
-
-      const response = createMockResponse(chunks) as Response;
+    it("should emit text deltas", async () => {
+      const response = createMockResponse([
+        textDelta("Hello"),
+        textDelta(" World"),
+        completed,
+      ]);
       const onContent = vi.fn();
       const onComplete = vi.fn();
 
-      await streamProcessor.processStream(response, {
-        onContent,
-        onComplete,
-      });
+      await streamProcessor.processStream(response, { onContent, onComplete });
 
       expect(onContent).toHaveBeenCalledWith("Hello");
       expect(onContent).toHaveBeenCalledWith(" World");
       expect(onComplete).toHaveBeenCalled();
     });
 
-    it("should handle tool calls correctly", async () => {
-      const chunks = [
-        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"get_page"}}]},"finish_reason":null}]}\n',
-        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"_text","arguments":"{}"}}]},"finish_reason":null}]}\n',
-        'data: {"choices":[{"finish_reason":"tool_calls"}]}\n',
-      ];
-
-      const response = createMockResponse(chunks) as Response;
+    it("should collect function calls and skip completion", async () => {
+      const response = createMockResponse([
+        'data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"get_current_time"}}\n',
+        'data: {"type":"response.function_call_arguments.delta","delta":"{}"}\n',
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"get_current_time","arguments":"{}"}}\n',
+        completed,
+      ]);
       const onToolCalls = vi.fn();
       const onComplete = vi.fn();
 
@@ -69,53 +69,61 @@ describe("StreamProcessor", () => {
 
       expect(onToolCalls).toHaveBeenCalledWith([
         {
-          id: "call_1",
-          type: "function",
-          function: {
-            name: "get_page_text",
-            arguments: "{}",
-          },
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "get_current_time",
+          arguments: "{}",
+        },
+      ]);
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it("should collect multiple function calls", async () => {
+      const response = createMockResponse([
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"tool1","arguments":"{}"}}\n',
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_2","name":"tool2","arguments":"{}"}}\n',
+        completed,
+      ]);
+      const onToolCalls = vi.fn();
+
+      await streamProcessor.processStream(response, { onToolCalls });
+
+      expect(onToolCalls).toHaveBeenCalledWith([
+        expect.objectContaining({ call_id: "call_1", name: "tool1" }),
+        expect.objectContaining({ call_id: "call_2", name: "tool2" }),
+      ]);
+    });
+
+    it("should report built-in web search calls as tool activity", async () => {
+      const response = createMockResponse([
+        'data: {"type":"response.web_search_call.searching","item_id":"ws_1"}\n',
+        'data: {"type":"response.output_item.done","item":{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"emerald extension"}}}\n',
+        textDelta("Here is what I found"),
+        completed,
+      ]);
+      const onToolActivity = vi.fn();
+      const onComplete = vi.fn();
+
+      await streamProcessor.processStream(response, {
+        onToolActivity,
+        onComplete,
+      });
+
+      expect(onToolActivity).toHaveBeenCalledWith([
+        {
+          name: "web_search",
+          arguments: JSON.stringify({ query: "emerald extension" }),
+          result: "completed",
         },
       ]);
       expect(onComplete).toHaveBeenCalled();
     });
 
-    it("should handle multiple tool calls", async () => {
-      const chunks = [
-        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"tool1","arguments":"{}"}},{"index":1,"id":"call_2","function":{"name":"tool2","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}\n',
-      ];
-
-      const response = createMockResponse(chunks) as Response;
-      const onToolCalls = vi.fn();
-
-      await streamProcessor.processStream(response, {
-        onToolCalls,
-      });
-
-      expect(onToolCalls).toHaveBeenCalledWith([
-        {
-          id: "call_1",
-          type: "function",
-          function: {
-            name: "tool1",
-            arguments: "{}",
-          },
-        },
-        {
-          id: "call_2",
-          type: "function",
-          function: {
-            name: "tool2",
-            arguments: "{}",
-          },
-        },
+    it("should handle error events", async () => {
+      const response = createMockResponse([
+        'data: {"type":"error","code":"server_error","message":"API Error occurred"}\n',
       ]);
-    });
-
-    it("should handle API errors", async () => {
-      const chunks = ['data: {"error":{"message":"API Error occurred"}}\n'];
-
-      const response = createMockResponse(chunks) as Response;
       const onError = vi.fn();
 
       await expect(
@@ -123,25 +131,35 @@ describe("StreamProcessor", () => {
       ).rejects.toThrow(StreamError);
 
       expect(onError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: "API Error occurred",
-        }),
+        expect.objectContaining({ message: "API Error occurred" }),
       );
     });
 
-    it("should handle invalid JSON", async () => {
-      const chunks = ["data: {invalid json}\n"];
-
-      const response = createMockResponse(chunks) as Response;
+    it("should handle failed responses", async () => {
+      const response = createMockResponse([
+        'data: {"type":"response.failed","response":{"status":"failed","error":{"message":"Rate limited"}}}\n',
+      ]);
       const onError = vi.fn();
 
       await expect(
         streamProcessor.processStream(response, { onError }),
       ).rejects.toThrow(StreamError);
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Rate limited" }),
+      );
+    });
+
+    it("should handle invalid JSON", async () => {
+      const response = createMockResponse(["data: {invalid json}\n"]);
+
+      await expect(streamProcessor.processStream(response, {})).rejects.toThrow(
+        StreamError,
+      );
     });
 
     it("should handle null response body", async () => {
-      const response = createMockResponse([], false) as Response;
+      const response = createMockResponse([], false);
 
       await expect(streamProcessor.processStream(response, {})).rejects.toThrow(
         StreamError,
@@ -149,15 +167,14 @@ describe("StreamProcessor", () => {
     });
 
     it("should handle reader errors", async () => {
-      const mockReader = {
-        read: vi.fn().mockRejectedValue(new Error("Reader error")),
-      };
-
       const response = {
         ok: true,
-        body: { getReader: () => mockReader },
+        body: {
+          getReader: () => ({
+            read: vi.fn().mockRejectedValue(new Error("Reader error")),
+          }),
+        },
       } as unknown as Response;
-
       const onError = vi.fn();
 
       await expect(
@@ -165,26 +182,19 @@ describe("StreamProcessor", () => {
       ).rejects.toThrow(StreamError);
 
       expect(onError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: "Stream processing failed",
-        }),
+        expect.objectContaining({ message: "Stream processing failed" }),
       );
     });
 
-    it("should handle multiple lines in single chunk", async () => {
-      const chunks = [
-        'data: {"choices":[{"delta":{"content":"First"}}]}\ndata: {"choices":[{"delta":{"content":" Second"}}]}\n',
-        'data: {"choices":[{"delta":{"content":" Third"}}]}\ndata: [DONE]\n',
-      ];
-
-      const response = createMockResponse(chunks) as Response;
+    it("should handle multiple lines in a single chunk", async () => {
+      const response = createMockResponse([
+        textDelta("First") + textDelta(" Second"),
+        textDelta(" Third") + completed,
+      ]);
       const onContent = vi.fn();
       const onComplete = vi.fn();
 
-      await streamProcessor.processStream(response, {
-        onContent,
-        onComplete,
-      });
+      await streamProcessor.processStream(response, { onContent, onComplete });
 
       expect(onContent).toHaveBeenCalledTimes(3);
       expect(onContent).toHaveBeenNthCalledWith(1, "First");
@@ -194,110 +204,56 @@ describe("StreamProcessor", () => {
     });
 
     it("should handle partial chunks correctly", async () => {
-      const chunks = [
-        'data: {"choices":[{"delta":{"con',
-        'tent":"Hello"}}]}\ndata: [DONE]\n',
-      ];
-
-      const response = createMockResponse(chunks) as Response;
+      const response = createMockResponse([
+        'data: {"type":"response.output_te',
+        'xt.delta","delta":"Hello"}\n' + completed,
+      ]);
       const onContent = vi.fn();
       const onComplete = vi.fn();
 
-      await streamProcessor.processStream(response, {
-        onContent,
-        onComplete,
-      });
+      await streamProcessor.processStream(response, { onContent, onComplete });
 
       expect(onContent).toHaveBeenCalledWith("Hello");
       expect(onComplete).toHaveBeenCalled();
     });
 
-    it("should ignore non-JSON data lines", async () => {
-      const chunks = [
+    it("should ignore unrelated events and non-JSON data lines", async () => {
+      const response = createMockResponse([
+        "event: response.created\n",
         "data: some-non-json-data\n",
-        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
-        "data: [DONE]\n",
-      ];
-
-      const response = createMockResponse(chunks) as Response;
+        'data: {"type":"response.reasoning_summary_text.delta","delta":"thinking"}\n',
+        textDelta("Hello"),
+        completed,
+      ]);
       const onContent = vi.fn();
       const onComplete = vi.fn();
 
-      await streamProcessor.processStream(response, {
-        onContent,
-        onComplete,
-      });
+      await streamProcessor.processStream(response, { onContent, onComplete });
 
+      expect(onContent).toHaveBeenCalledTimes(1);
       expect(onContent).toHaveBeenCalledWith("Hello");
-      expect(onComplete).toHaveBeenCalled();
-    });
-
-    it("should handle empty choices array", async () => {
-      const chunks = ['data: {"choices":[]}\n', "data: [DONE]\n"];
-
-      const response = createMockResponse(chunks) as Response;
-      const onContent = vi.fn();
-      const onComplete = vi.fn();
-
-      await streamProcessor.processStream(response, {
-        onContent,
-        onComplete,
-      });
-
-      expect(onContent).not.toHaveBeenCalled();
-      expect(onComplete).toHaveBeenCalled();
-    });
-
-    it("should filter out incomplete tool calls", async () => {
-      // Test passes if no exception is thrown and process completes
-      const chunks = [
-        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"","function":{"name":"","arguments":""}}]},"finish_reason":null}]}\n',
-        'data: {"choices":[{"finish_reason":"tool_calls"}]}\n',
-      ];
-
-      const response = createMockResponse(chunks) as Response;
-      const onComplete = vi.fn();
-
-      await streamProcessor.processStream(response, {
-        onComplete,
-      });
-
       expect(onComplete).toHaveBeenCalled();
     });
   });
 
   describe("reset", () => {
-    it("should reset internal state", async () => {
-      const chunks = [
-        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"test"}}]},"finish_reason":null}]}\n',
-      ];
+    it("should drop collected function calls", async () => {
+      const first = createMockResponse([
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"test","arguments":"{}"}}\n',
+      ]);
 
-      const response = createMockResponse(chunks) as Response;
-
-      await streamProcessor.processStream(response, {});
-
+      await streamProcessor.processStream(first, {});
       streamProcessor.reset();
 
-      const chunks2 = [
-        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_2","function":{"name":"test2"}}]},"finish_reason":"tool_calls"}]}\n',
-      ];
-
-      const response2 = createMockResponse(chunks2) as Response;
+      const second = createMockResponse([
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_2","name":"test2","arguments":"{}"}}\n',
+      ]);
       const onToolCalls = vi.fn();
 
-      await streamProcessor.processStream(response2, {
-        onToolCalls,
-      });
+      await streamProcessor.processStream(second, { onToolCalls });
 
       expect(onToolCalls).toHaveBeenCalledWith([
-        {
-          id: "call_2",
-          type: "function",
-          function: {
-            name: "test2",
-            arguments: "",
-          },
-        },
+        expect.objectContaining({ call_id: "call_2", name: "test2" }),
       ]);
     });
   });

--- a/src/lib/openai/__tests__/title-generator.test.ts
+++ b/src/lib/openai/__tests__/title-generator.test.ts
@@ -10,16 +10,21 @@ function makeMessage(
   return { id, sender, content, timestamp: 0 };
 }
 
-const config = {
-  apiKey: "sk-test",
-  model: "gpt-5.4",
-  baseUrl: "https://api.openai.com/v1/chat/completions",
-};
+const config = { apiKey: "sk-test" };
 
-function mockResponse(content: string) {
+function mockResponse(text: string) {
   return {
     ok: true,
-    json: async () => ({ choices: [{ message: { content } }] }),
+    json: async () => ({
+      output: [
+        { type: "reasoning", summary: [] },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text, annotations: [] }],
+        },
+      ],
+    }),
   } as Response;
 }
 
@@ -44,11 +49,15 @@ describe("generateConversationTitle", () => {
 
     expect(title).toBe("React hooks の使い方");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://api.openai.com/v1/responses",
+    );
 
     const body = JSON.parse(
       (fetchMock.mock.calls[0][1] as RequestInit).body as string,
     );
-    expect(body.model).toBe("gpt-5.4");
+    expect(body.model).toBe("gpt-5.6-luna");
+    expect(body.reasoning).toEqual({ effort: "max" });
     expect(body.stream).toBe(false);
   });
 
@@ -85,10 +94,10 @@ describe("generateConversationTitle", () => {
     expect(title).toBeNull();
   });
 
-  it("returns null when the response has no string content", async () => {
+  it("returns null when the response has no text output", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
-      json: async () => ({ choices: [] }),
+      json: async () => ({ output: [{ type: "reasoning", summary: [] }] }),
     } as Response);
 
     const title = await generateConversationTitle(config, [

--- a/src/lib/openai/client.ts
+++ b/src/lib/openai/client.ts
@@ -1,44 +1,34 @@
 import {
-  OpenAIRequest,
-  OpenAIMessage,
-  ToolCall,
-  ToolResult,
   ApiError,
+  FunctionCallItem,
+  FunctionCallOutputItem,
+  ResponseInputItem,
+  ResponsesRequest,
 } from "../../types/openai";
+import { MODEL, REASONING_EFFORT, RESPONSES_URL } from "./constants";
 import { StreamProcessor, StreamCallbacks } from "./stream-processor";
 import { ToolExecutor, getAvailableTools } from "../tools/executor";
 
 export interface OpenAIClientConfig {
   apiKey: string;
-  model?: string;
-  baseUrl?: string;
-  braveApiKey?: string;
 }
 
-const DEFAULT_CONFIG = {
-  model: "gpt-5.4",
-  baseUrl: "https://api.openai.com/v1/chat/completions",
-  braveApiKey: "",
-};
-
 export class OpenAIClient {
-  private config: Required<OpenAIClientConfig>;
+  private apiKey: string;
   private streamProcessor: StreamProcessor;
   private toolExecutor: ToolExecutor;
 
   constructor(config: OpenAIClientConfig) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.apiKey = config.apiKey;
     this.streamProcessor = new StreamProcessor();
-    this.toolExecutor = new ToolExecutor({
-      braveApiKey: this.config.braveApiKey,
-    });
+    this.toolExecutor = new ToolExecutor();
   }
 
   async sendMessage(
-    messages: OpenAIMessage[],
+    input: ResponseInputItem[],
     callbacks: StreamCallbacks,
   ): Promise<void> {
-    const request = this.buildRequest(messages);
+    const request = this.buildRequest(input);
 
     try {
       const response = await this.makeRequest(request);
@@ -50,7 +40,7 @@ export class OpenAIClient {
         );
       }
 
-      const enhancedCallbacks = this.wrapCallbacks(callbacks, messages);
+      const enhancedCallbacks = this.wrapCallbacks(callbacks, input);
       await this.streamProcessor.processStream(response, enhancedCallbacks);
     } catch (error) {
       if (error instanceof ApiError) {
@@ -64,22 +54,23 @@ export class OpenAIClient {
     }
   }
 
-  private buildRequest(messages: OpenAIMessage[]): OpenAIRequest {
+  private buildRequest(input: ResponseInputItem[]): ResponsesRequest {
     return {
-      model: this.config.model,
-      messages,
-      tools: getAvailableTools({ braveApiKey: this.config.braveApiKey }),
+      model: MODEL,
+      input,
+      tools: getAvailableTools(),
       tool_choice: "auto",
+      reasoning: { effort: REASONING_EFFORT },
       stream: true,
     };
   }
 
-  private async makeRequest(request: OpenAIRequest): Promise<Response> {
-    return fetch(this.config.baseUrl, {
+  private async makeRequest(request: ResponsesRequest): Promise<Response> {
+    return fetch(RESPONSES_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.config.apiKey}`,
+        Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(request),
     });
@@ -87,18 +78,18 @@ export class OpenAIClient {
 
   private wrapCallbacks(
     originalCallbacks: StreamCallbacks,
-    messages: OpenAIMessage[],
+    input: ResponseInputItem[],
   ): StreamCallbacks {
     return {
       ...originalCallbacks,
-      onToolCalls: async (toolCalls: ToolCall[]) => {
+      onToolCalls: async (functionCalls: FunctionCallItem[]) => {
         try {
-          const toolResults = await this.toolExecutor.execute(toolCalls);
-          this.reportToolActivity(toolCalls, toolResults, originalCallbacks);
-          await this.handleToolResults(
-            messages,
-            toolCalls,
-            toolResults,
+          const outputs = await this.toolExecutor.execute(functionCalls);
+          this.reportToolActivity(functionCalls, outputs, originalCallbacks);
+          await this.continueWithToolOutputs(
+            input,
+            functionCalls,
+            outputs,
             originalCallbacks,
           );
         } catch (error) {
@@ -111,42 +102,47 @@ export class OpenAIClient {
   }
 
   private reportToolActivity(
-    toolCalls: ToolCall[],
-    toolResults: ToolResult[],
+    functionCalls: FunctionCallItem[],
+    outputs: FunctionCallOutputItem[],
     callbacks: StreamCallbacks,
   ): void {
     if (!callbacks.onToolActivity) return;
 
-    const resultById = new Map(
-      toolResults.map((result) => [result.tool_call_id, result.content]),
+    const outputByCallId = new Map(
+      outputs.map((output) => [output.call_id, output.output]),
     );
 
-    const interactions = toolCalls.map((toolCall) => ({
-      name: toolCall.function.name,
-      arguments: toolCall.function.arguments,
-      result: resultById.get(toolCall.id) ?? "",
+    const interactions = functionCalls.map((functionCall) => ({
+      name: functionCall.name,
+      arguments: functionCall.arguments,
+      result: outputByCallId.get(functionCall.call_id) ?? "",
     }));
 
     callbacks.onToolActivity(interactions);
   }
 
-  private async handleToolResults(
-    messages: OpenAIMessage[],
-    toolCalls: ToolCall[],
-    toolResults: ToolResult[],
+  private async continueWithToolOutputs(
+    input: ResponseInputItem[],
+    functionCalls: FunctionCallItem[],
+    outputs: FunctionCallOutputItem[],
     callbacks: StreamCallbacks,
   ): Promise<void> {
-    const updatedMessages: OpenAIMessage[] = [
-      ...messages,
-      {
-        role: "assistant",
-        content: null,
-        tool_calls: toolCalls,
-      },
-      ...toolResults,
+    const replayedCalls: ResponseInputItem[] = functionCalls.map(
+      ({ call_id, name, arguments: args }) => ({
+        type: "function_call",
+        call_id,
+        name,
+        arguments: args,
+      }),
+    );
+
+    const updatedInput: ResponseInputItem[] = [
+      ...input,
+      ...replayedCalls,
+      ...outputs,
     ];
 
     this.streamProcessor.reset();
-    await this.sendMessage(updatedMessages, callbacks);
+    await this.sendMessage(updatedInput, callbacks);
   }
 }

--- a/src/lib/openai/constants.ts
+++ b/src/lib/openai/constants.ts
@@ -1,0 +1,7 @@
+import { ReasoningEffort } from "../../types/openai";
+
+export const RESPONSES_URL = "https://api.openai.com/v1/responses";
+
+export const MODEL = "gpt-5.6-luna";
+
+export const REASONING_EFFORT: ReasoningEffort = "max";

--- a/src/lib/openai/stream-processor.ts
+++ b/src/lib/openai/stream-processor.ts
@@ -1,17 +1,30 @@
-import { OpenAIStreamChunk, ToolCall, StreamError } from "../../types/openai";
+import {
+  FunctionCallItem,
+  ResponseOutputItem,
+  ResponseStreamEvent,
+  StreamError,
+} from "../../types/openai";
 import { ToolInteraction } from "../../types";
 
 export interface StreamCallbacks {
   onContent?: (content: string) => void;
-  onToolCalls?: (toolCalls: ToolCall[]) => void;
+  onToolCalls?: (functionCalls: FunctionCallItem[]) => void | Promise<void>;
   onToolActivity?: (interactions: ToolInteraction[]) => void;
   onComplete?: () => void;
   onError?: (error: Error) => void;
 }
 
+/**
+ * Parses the server-sent event stream of the Responses API.
+ *
+ * Text arrives as `response.output_text.delta` events. Completed items arrive
+ * as `response.output_item.done`: function calls have to be executed locally
+ * and answered with a follow-up request, while hosted tools such as web search
+ * are already resolved by OpenAI and only reported for visibility.
+ */
 export class StreamProcessor {
   private buffer = "";
-  private toolCallsBuffer: { [index: string]: Partial<ToolCall> } = {};
+  private functionCalls: FunctionCallItem[] = [];
 
   async processStream(
     response: Response,
@@ -30,11 +43,12 @@ export class StreamProcessor {
         if (done) break;
 
         this.buffer += decoder.decode(value, { stream: true });
-        await this.processBuffer(callbacks);
+        this.processBuffer(callbacks);
       }
-
-      callbacks.onComplete?.();
     } catch (error) {
+      if (error instanceof StreamError) {
+        throw error;
+      }
       const streamError = new StreamError(
         "Stream processing failed",
         error instanceof Error ? error : undefined,
@@ -42,48 +56,40 @@ export class StreamProcessor {
       callbacks.onError?.(streamError);
       throw streamError;
     }
+
+    if (this.functionCalls.length > 0) {
+      await callbacks.onToolCalls?.(this.functionCalls);
+      return;
+    }
+
+    callbacks.onComplete?.();
   }
 
-  private async processBuffer(callbacks: StreamCallbacks): Promise<void> {
+  private processBuffer(callbacks: StreamCallbacks): void {
     const lines = this.buffer.split("\n");
     this.buffer = lines.pop() as string;
 
     for (const line of lines) {
-      if (line.startsWith("data: ")) {
-        const data = line.slice(6);
+      if (!line.startsWith("data: ")) continue;
 
-        if (data === "[DONE]") {
-          return;
-        }
+      const data = line.slice(6);
+      if (!data.startsWith("{")) continue;
 
-        if (data.startsWith("{")) {
-          try {
-            const chunk = this.parseChunk(data);
-            await this.processChunk(chunk, callbacks);
-          } catch (error) {
-            if (error instanceof StreamError) {
-              callbacks.onError?.(error);
-              throw error;
-            }
-          }
+      try {
+        this.processEvent(this.parseEvent(data), callbacks);
+      } catch (error) {
+        if (error instanceof StreamError) {
+          callbacks.onError?.(error);
+          throw error;
         }
       }
     }
   }
 
-  private parseChunk(data: string): OpenAIStreamChunk {
+  private parseEvent(data: string): ResponseStreamEvent {
     try {
-      const parsed = JSON.parse(data) as OpenAIStreamChunk;
-
-      if (parsed.error) {
-        throw new StreamError(parsed.error.message || "OpenAI API Error");
-      }
-
-      return parsed;
+      return JSON.parse(data) as ResponseStreamEvent;
     } catch (error) {
-      if (error instanceof StreamError) {
-        throw error;
-      }
       throw new StreamError(
         "Invalid JSON in stream",
         error instanceof Error ? error : undefined,
@@ -91,95 +97,61 @@ export class StreamProcessor {
     }
   }
 
-  private async processChunk(
-    chunk: OpenAIStreamChunk,
+  private processEvent(
+    event: ResponseStreamEvent,
     callbacks: StreamCallbacks,
-  ): Promise<void> {
-    const choice = chunk.choices?.[0];
-    if (!choice) return;
-
-    const { delta, finish_reason } = choice;
-
-    if (delta?.content) {
-      callbacks.onContent?.(delta.content);
-    }
-
-    if (delta?.tool_calls) {
-      this.processToolCallsDeltas(delta.tool_calls);
-    }
-
-    if (finish_reason === "tool_calls") {
-      const toolCalls = this.buildToolCallsFromBuffer();
-      if (toolCalls.length > 0) {
-        callbacks.onToolCalls?.(toolCalls);
-      }
-    }
-  }
-
-  private processToolCallsDeltas(
-    toolCallsDeltas: Array<{
-      index: number;
-      id?: string;
-      type?: "function";
-      function?: {
-        name?: string;
-        arguments?: string;
-      };
-    }>,
   ): void {
-    for (const delta of toolCallsDeltas) {
-      const index = delta.index.toString();
-
-      if (!this.toolCallsBuffer[index]) {
-        this.toolCallsBuffer[index] = {
-          id: "",
-          type: "function",
-          function: {
-            name: "",
-            arguments: "",
-          },
-        };
-      }
-
-      const bufferedToolCall = this.toolCallsBuffer[index];
-
-      if (delta.id) {
-        bufferedToolCall.id = (bufferedToolCall.id || "") + delta.id;
-      }
-
-      if (delta.function) {
-        if (delta.function.name) {
-          bufferedToolCall.function!.name =
-            (bufferedToolCall.function!.name || "") + delta.function.name;
+    switch (event.type) {
+      case "response.output_text.delta":
+        if (event.delta) {
+          callbacks.onContent?.(event.delta);
         }
-        if (delta.function.arguments) {
-          bufferedToolCall.function!.arguments =
-            (bufferedToolCall.function!.arguments || "") +
-            delta.function.arguments;
+        return;
+      case "response.output_item.done":
+        if (event.item) {
+          this.processOutputItem(event.item, callbacks);
         }
-      }
+        return;
+      case "error":
+        throw new StreamError(event.message || "OpenAI API Error");
+      case "response.failed":
+      case "response.incomplete":
+        throw new StreamError(
+          event.response?.error?.message || "OpenAI API Error",
+        );
+      default:
+        return;
     }
   }
 
-  private buildToolCallsFromBuffer(): ToolCall[] {
-    return Object.keys(this.toolCallsBuffer)
-      .sort((a, b) => parseInt(a) - parseInt(b))
-      .map((key) => {
-        const buffered = this.toolCallsBuffer[key];
-        return {
-          id: buffered.id || "",
-          type: "function" as const,
-          function: {
-            name: buffered.function?.name || "",
-            arguments: buffered.function?.arguments || "",
-          },
-        };
-      })
-      .filter((toolCall) => toolCall.id && toolCall.function.name);
+  private processOutputItem(
+    item: ResponseOutputItem,
+    callbacks: StreamCallbacks,
+  ): void {
+    if (item.type === "function_call" && item.call_id && item.name) {
+      this.functionCalls.push({
+        type: "function_call",
+        id: item.id,
+        call_id: item.call_id,
+        name: item.name,
+        arguments: item.arguments || "",
+      });
+      return;
+    }
+
+    if (item.type === "web_search_call") {
+      callbacks.onToolActivity?.([
+        {
+          name: "web_search",
+          arguments: JSON.stringify({ query: item.action?.query ?? "" }),
+          result: item.status ?? "completed",
+        },
+      ]);
+    }
   }
 
   reset(): void {
     this.buffer = "";
-    this.toolCallsBuffer = {};
+    this.functionCalls = [];
   }
 }

--- a/src/lib/openai/title-generator.ts
+++ b/src/lib/openai/title-generator.ts
@@ -1,9 +1,8 @@
 import { Message } from "../../types";
+import { MODEL, REASONING_EFFORT, RESPONSES_URL } from "./constants";
 
 export interface TitleGeneratorConfig {
   apiKey: string;
-  model: string;
-  baseUrl: string;
 }
 
 const MAX_CHARS_PER_MESSAGE = 600;
@@ -30,8 +29,24 @@ function sanitizeTitle(raw: string): string {
     .trim();
 }
 
+/** Concatenate the text parts of the assistant message items in a response. */
+function extractOutputText(data: unknown): string {
+  const output = (data as { output?: unknown }).output;
+  if (!Array.isArray(output)) return "";
+
+  return output
+    .filter((item) => (item as { type?: string }).type === "message")
+    .flatMap((item) => {
+      const content = (item as { content?: unknown }).content;
+      return Array.isArray(content) ? content : [];
+    })
+    .filter((part) => (part as { type?: string }).type === "output_text")
+    .map((part) => (part as { text?: string }).text ?? "")
+    .join("");
+}
+
 /**
- * Generate a short title for the conversation using the configured model.
+ * Generate a short title for the conversation.
  * Returns null on any failure so the upload can fall back to a default title.
  */
 export async function generateConversationTitle(
@@ -42,16 +57,17 @@ export async function generateConversationTitle(
   if (!transcript) return null;
 
   try {
-    const response = await fetch(config.baseUrl, {
+    const response = await fetch(RESPONSES_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${config.apiKey}`,
       },
       body: JSON.stringify({
-        model: config.model,
+        model: MODEL,
+        reasoning: { effort: REASONING_EFFORT },
         stream: false,
-        messages: [
+        input: [
           {
             role: "system",
             content:
@@ -69,11 +85,7 @@ export async function generateConversationTitle(
 
     if (!response.ok) return null;
 
-    const data = await response.json();
-    const raw: unknown = data?.choices?.[0]?.message?.content;
-    if (typeof raw !== "string") return null;
-
-    const title = sanitizeTitle(raw);
+    const title = sanitizeTitle(extractOutputText(await response.json()));
     return title || null;
   } catch {
     return null;

--- a/src/lib/tools/__tests__/executor.test.ts
+++ b/src/lib/tools/__tests__/executor.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ToolExecutor, getAvailableTools } from "../executor";
-import { ToolCall } from "../../../types/openai";
+import { FunctionCallItem } from "../../../types/openai";
+
+const functionCall = (
+  callId: string,
+  name: string,
+  args = "{}",
+): FunctionCallItem => ({
+  type: "function_call",
+  call_id: callId,
+  name,
+  arguments: args,
+});
 
 describe("ToolExecutor", () => {
   let toolExecutor: ToolExecutor;
@@ -12,204 +23,72 @@ describe("ToolExecutor", () => {
 
   describe("execute", () => {
     it("should execute get_current_time tool successfully", async () => {
-      const toolCalls: ToolCall[] = [
-        {
-          id: "test-id-1",
-          type: "function",
-          function: {
-            name: "get_current_time",
-            arguments: "{}",
-          },
-        },
-      ];
-
-      const results = await toolExecutor.execute(toolCalls);
+      const results = await toolExecutor.execute([
+        functionCall("test-id-1", "get_current_time"),
+      ]);
 
       expect(results).toHaveLength(1);
-      expect(results[0].tool_call_id).toBe("test-id-1");
-      expect(results[0].role).toBe("tool");
-      expect(results[0].content).toMatch(/^Current local time:/);
+      expect(results[0].type).toBe("function_call_output");
+      expect(results[0].call_id).toBe("test-id-1");
+      expect(results[0].output).toMatch(/^Current local time:/);
     });
 
     it("should handle unknown tool", async () => {
-      const toolCalls: ToolCall[] = [
+      const results = await toolExecutor.execute([
+        functionCall("test-id-1", "unknown_tool"),
+      ]);
+
+      expect(results).toEqual([
         {
-          id: "test-id-1",
-          type: "function",
-          function: {
-            name: "unknown_tool",
-            arguments: "{}",
-          },
+          type: "function_call_output",
+          call_id: "test-id-1",
+          output: "Error: Unknown tool: unknown_tool",
         },
-      ];
-
-      const results = await toolExecutor.execute(toolCalls);
-
-      expect(results).toHaveLength(1);
-      expect(results[0]).toEqual({
-        tool_call_id: "test-id-1",
-        role: "tool",
-        content: "Error: Unknown tool: unknown_tool",
-      });
+      ]);
     });
 
     it("should execute multiple tools", async () => {
-      const toolCalls: ToolCall[] = [
-        {
-          id: "test-id-1",
-          type: "function",
-          function: {
-            name: "get_current_time",
-            arguments: "{}",
-          },
-        },
-        {
-          id: "test-id-2",
-          type: "function",
-          function: {
-            name: "get_current_time",
-            arguments: "{}",
-          },
-        },
-      ];
-
-      const results = await toolExecutor.execute(toolCalls);
+      const results = await toolExecutor.execute([
+        functionCall("test-id-1", "get_current_time"),
+        functionCall("test-id-2", "get_current_time"),
+      ]);
 
       expect(results).toHaveLength(2);
-      expect(results[0].tool_call_id).toBe("test-id-1");
-      expect(results[0].content).toMatch(/^Current local time:/);
-      expect(results[1].tool_call_id).toBe("test-id-2");
-      expect(results[1].content).toMatch(/^Current local time:/);
+      expect(results[0].call_id).toBe("test-id-1");
+      expect(results[0].output).toMatch(/^Current local time:/);
+      expect(results[1].call_id).toBe("test-id-2");
+      expect(results[1].output).toMatch(/^Current local time:/);
     });
 
     it("should handle mixed success and error cases", async () => {
-      const toolCalls: ToolCall[] = [
-        {
-          id: "test-id-1",
-          type: "function",
-          function: {
-            name: "get_current_time",
-            arguments: "{}",
-          },
-        },
-        {
-          id: "test-id-2",
-          type: "function",
-          function: {
-            name: "unknown_tool",
-            arguments: "{}",
-          },
-        },
-      ];
-
-      const results = await toolExecutor.execute(toolCalls);
+      const results = await toolExecutor.execute([
+        functionCall("test-id-1", "get_current_time"),
+        functionCall("test-id-2", "unknown_tool"),
+      ]);
 
       expect(results).toHaveLength(2);
-      expect(results[0].content).toMatch(/^Current local time:/);
-      expect(results[1]).toEqual({
-        tool_call_id: "test-id-2",
-        role: "tool",
-        content: "Error: Unknown tool: unknown_tool",
-      });
+      expect(results[0].output).toMatch(/^Current local time:/);
+      expect(results[1].output).toBe("Error: Unknown tool: unknown_tool");
     });
   });
 
   describe("getAvailableTools", () => {
-    it("does not include web_search without a Brave API key", () => {
-      const names = getAvailableTools().map((t) => t.function.name);
-      expect(names).toContain("get_current_time");
-      expect(names).not.toContain("web_search");
-    });
-
-    it("includes web_search when a Brave API key is set", () => {
-      const names = getAvailableTools({ braveApiKey: "test-key" }).map(
-        (t) => t.function.name,
+    it("exposes the local function tools in the Responses API format", () => {
+      const functionTools = getAvailableTools().filter(
+        (tool) => tool.type === "function",
       );
-      expect(names).toContain("web_search");
-    });
-  });
 
-  describe("web_search", () => {
-    const searchCall: ToolCall[] = [
-      {
-        id: "search-1",
-        type: "function",
-        function: {
-          name: "web_search",
-          arguments: JSON.stringify({ query: "emerald chrome extension" }),
-        },
-      },
-    ];
-
-    it("returns an error when no Brave API key is configured", async () => {
-      const results = await new ToolExecutor().execute(searchCall);
-
-      expect(results[0].content).toBe(
-        "Error: Brave API key is not configured.",
-      );
-    });
-
-    it("calls the Brave API and formats results with source URLs", async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          web: {
-            results: [
-              {
-                title: "Result A",
-                url: "https://example.com/a",
-                description: "Snippet A",
-              },
-              {
-                title: "Result B",
-                url: "https://example.com/b",
-                description: "Snippet B",
-              },
-            ],
-          },
+      expect(functionTools).toEqual([
+        expect.objectContaining({
+          type: "function",
+          name: "get_current_time",
+          strict: true,
         }),
-      });
-      globalThis.fetch = fetchMock;
-
-      const executor = new ToolExecutor({ braveApiKey: "brave-key" });
-      const results = await executor.execute(searchCall);
-
-      const [calledUrl, calledInit] = fetchMock.mock.calls[0];
-      expect(calledUrl).toContain(
-        "https://api.search.brave.com/res/v1/web/search",
-      );
-      expect(calledUrl).toContain("q=emerald");
-      expect(calledInit.headers["X-Subscription-Token"]).toBe("brave-key");
-
-      expect(results[0].content).toContain("https://example.com/a");
-      expect(results[0].content).toContain("https://example.com/b");
-      expect(results[0].content).toContain("Result A");
+      ]);
     });
 
-    it("returns a message when there are no results", async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ web: { results: [] } }),
-      });
-
-      const executor = new ToolExecutor({ braveApiKey: "brave-key" });
-      const results = await executor.execute(searchCall);
-
-      expect(results[0].content).toBe("No search results found.");
-    });
-
-    it("returns an error message on HTTP failure", async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 429,
-      });
-
-      const executor = new ToolExecutor({ braveApiKey: "brave-key" });
-      const results = await executor.execute(searchCall);
-
-      expect(results[0].content).toBe(
-        "Error: Brave Search API returned HTTP 429",
-      );
+    it("enables the built-in web search tool", () => {
+      expect(getAvailableTools()).toContainEqual({ type: "web_search" });
     });
   });
 });

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -1,88 +1,55 @@
-import { ToolCall, ToolResult, ToolExecutionError } from "../../types/openai";
+import {
+  FunctionCallItem,
+  FunctionCallOutputItem,
+  FunctionTool,
+  ToolDefinition,
+  ToolExecutionError,
+  WebSearchTool,
+} from "../../types/openai";
 
-export interface ToolDefinition {
-  type: "function";
-  function: {
-    name: string;
-    description: string;
-    parameters: {
-      type: "object";
-      properties: Record<string, unknown>;
-      required: string[];
-    };
-  };
-}
-
-export const AVAILABLE_TOOLS: ToolDefinition[] = [
+export const AVAILABLE_TOOLS: FunctionTool[] = [
   {
     type: "function",
-    function: {
-      name: "get_current_time",
-      description:
-        "Get the current date and time. Use this tool IMMEDIATELY at the beginning of every conversation to establish temporal context. Always call this first regardless of what the user asks - knowing the current time is essential for providing accurate, contextually appropriate responses about schedules, deadlines, time-sensitive information, and general conversation context.",
-      parameters: {
-        type: "object",
-        properties: {},
-        required: [],
-      },
+    name: "get_current_time",
+    description:
+      "Get the current date and time. Use this tool IMMEDIATELY at the beginning of every conversation to establish temporal context. Always call this first regardless of what the user asks - knowing the current time is essential for providing accurate, contextually appropriate responses about schedules, deadlines, time-sensitive information, and general conversation context.",
+    parameters: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: false,
     },
+    strict: true,
   },
 ];
 
-export const WEB_SEARCH_TOOL: ToolDefinition = {
-  type: "function",
-  function: {
-    name: "web_search",
-    description:
-      "Search the web using the Brave Search API and return a list of results, each with a title, URL, and snippet. Use this whenever answering the user would benefit from up-to-date or external information: current events, news, facts you are unsure about, product/library documentation, or anything that may have changed recently. IMPORTANT: Whenever you use information obtained from this tool, you MUST cite the source URLs back to the user in your reply, formatted as Markdown links like [title](url), so the user can verify where the information came from.",
-    parameters: {
-      type: "object",
-      properties: {
-        query: {
-          type: "string",
-          description: "The search query.",
-        },
-      },
-      required: ["query"],
-    },
-  },
-};
+/**
+ * Hosted web search tool. OpenAI runs the search server side, so there is
+ * nothing to execute locally: results and citations arrive in the stream.
+ */
+export const WEB_SEARCH_TOOL: WebSearchTool = { type: "web_search" };
 
-export interface ToolExecutorOptions {
-  braveApiKey?: string;
-}
-
-export const getAvailableTools = (
-  options: ToolExecutorOptions = {},
-): ToolDefinition[] => {
-  const tools = [...AVAILABLE_TOOLS];
-  if (options.braveApiKey) {
-    tools.push(WEB_SEARCH_TOOL);
-  }
-  return tools;
-};
+export const getAvailableTools = (): ToolDefinition[] => [
+  ...AVAILABLE_TOOLS,
+  WEB_SEARCH_TOOL,
+];
 
 export class ToolExecutor {
-  private braveApiKey: string;
+  async execute(
+    functionCalls: FunctionCallItem[],
+  ): Promise<FunctionCallOutputItem[]> {
+    const results: FunctionCallOutputItem[] = [];
 
-  constructor(options: ToolExecutorOptions = {}) {
-    this.braveApiKey = options.braveApiKey || "";
-  }
-
-  async execute(toolCalls: ToolCall[]): Promise<ToolResult[]> {
-    const results: ToolResult[] = [];
-
-    for (const toolCall of toolCalls) {
+    for (const functionCall of functionCalls) {
       try {
-        const result = await this.executeSingleTool(toolCall);
-        results.push(result);
+        results.push(await this.executeSingleTool(functionCall));
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : "Unknown error occurred";
         results.push({
-          tool_call_id: toolCall.id,
-          role: "tool",
-          content: `Error: ${errorMessage}`,
+          type: "function_call_output",
+          call_id: functionCall.call_id,
+          output: `Error: ${errorMessage}`,
         });
       }
     }
@@ -90,103 +57,27 @@ export class ToolExecutor {
     return results;
   }
 
-  private async executeSingleTool(toolCall: ToolCall): Promise<ToolResult> {
-    const { function: func } = toolCall;
-
-    switch (func.name) {
+  private async executeSingleTool(
+    functionCall: FunctionCallItem,
+  ): Promise<FunctionCallOutputItem> {
+    switch (functionCall.name) {
       case "get_current_time":
-        return await this.executeGetCurrentTime(toolCall.id);
-      case "web_search":
-        return await this.executeWebSearch(toolCall.id, func.arguments);
+        return this.executeGetCurrentTime(functionCall.call_id);
       default:
-        throw new ToolExecutionError(`Unknown tool: ${func.name}`, func.name);
+        throw new ToolExecutionError(
+          `Unknown tool: ${functionCall.name}`,
+          functionCall.name,
+        );
     }
   }
 
-  private async executeGetCurrentTime(toolCallId: string): Promise<ToolResult> {
-    const now = new Date();
-    const localTime = now.toLocaleString();
+  private executeGetCurrentTime(callId: string): FunctionCallOutputItem {
+    const localTime = new Date().toLocaleString();
 
     return {
-      tool_call_id: toolCallId,
-      role: "tool",
-      content: `Current local time: ${localTime}`,
-    };
-  }
-
-  private async executeWebSearch(
-    toolCallId: string,
-    rawArguments: string,
-  ): Promise<ToolResult> {
-    if (!this.braveApiKey) {
-      return {
-        tool_call_id: toolCallId,
-        role: "tool",
-        content: "Error: Brave API key is not configured.",
-      };
-    }
-
-    let query = "";
-    try {
-      query = (JSON.parse(rawArguments || "{}").query as string) || "";
-    } catch {
-      query = "";
-    }
-
-    if (!query) {
-      return {
-        tool_call_id: toolCallId,
-        role: "tool",
-        content: "Error: query is required.",
-      };
-    }
-
-    const url = new URL("https://api.search.brave.com/res/v1/web/search");
-    url.searchParams.set("q", query);
-    url.searchParams.set("count", "10");
-    url.searchParams.set("search_lang", "jp");
-
-    const response = await fetch(url.toString(), {
-      headers: {
-        Accept: "application/json",
-        "X-Subscription-Token": this.braveApiKey,
-      },
-    });
-
-    if (!response.ok) {
-      return {
-        tool_call_id: toolCallId,
-        role: "tool",
-        content: `Error: Brave Search API returned HTTP ${response.status}`,
-      };
-    }
-
-    const data = await response.json();
-    const results = (data?.web?.results ?? []) as Array<{
-      title?: string;
-      url?: string;
-      description?: string;
-    }>;
-
-    if (results.length === 0) {
-      return {
-        tool_call_id: toolCallId,
-        role: "tool",
-        content: "No search results found.",
-      };
-    }
-
-    const content = results
-      .map(
-        (r) =>
-          `title: ${r.title ?? ""}\nurl: ${r.url ?? ""}\ncontent: ${r.description ?? ""}`,
-      )
-      .join("\n=================================\n\n");
-
-    return {
-      tool_call_id: toolCallId,
-      role: "tool",
-      content,
+      type: "function_call_output",
+      call_id: callId,
+      output: `Current local time: ${localTime}`,
     };
   }
 }

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -1,71 +1,97 @@
-export interface OpenAIMessage {
-  role: "system" | "user" | "assistant" | "tool";
-  content: string | OpenAIMessageContent[] | null;
-  tool_calls?: ToolCall[];
-  tool_call_id?: string;
+export type ResponseRole = "system" | "user" | "assistant";
+
+export interface ResponseInputText {
+  type: "input_text";
+  text: string;
 }
 
-export interface OpenAIMessageContent {
-  type: "text" | "image_url";
-  text?: string;
-  image_url?: { url: string };
+export interface ResponseInputImage {
+  type: "input_image";
+  image_url: string;
 }
 
-export interface ToolCall {
-  id: string;
+export type ResponseContentPart = ResponseInputText | ResponseInputImage;
+
+export interface ResponseMessageItem {
+  role: ResponseRole;
+  content: string | ResponseContentPart[];
+}
+
+export interface FunctionCallItem {
+  type: "function_call";
+  id?: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+}
+
+export interface FunctionCallOutputItem {
+  type: "function_call_output";
+  call_id: string;
+  output: string;
+}
+
+export type ResponseInputItem =
+  ResponseMessageItem | FunctionCallItem | FunctionCallOutputItem;
+
+export interface FunctionTool {
   type: "function";
-  function: {
-    name: string;
-    arguments: string;
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required: string[];
+    additionalProperties: false;
   };
+  strict: true;
 }
 
-export interface ToolResult {
-  tool_call_id: string;
-  role: "tool";
-  content: string;
+export interface WebSearchTool {
+  type: "web_search";
 }
 
-export interface OpenAIStreamChunk {
-  choices?: Array<{
-    delta?: {
-      content?: string;
-      tool_calls?: Array<{
-        index: number;
-        id?: string;
-        type?: "function";
-        function?: {
-          name?: string;
-          arguments?: string;
-        };
-      }>;
-    };
-    finish_reason?: "stop" | "length" | "tool_calls" | null;
-  }>;
-  error?: {
-    message: string;
-    type?: string;
-    code?: string;
-  };
-}
+export type ToolDefinition = FunctionTool | WebSearchTool;
 
-export interface OpenAIRequest {
+/** GPT-5.6 accepts none, low, medium, high, xhigh and max. */
+export type ReasoningEffort =
+  "none" | "low" | "medium" | "high" | "xhigh" | "max";
+
+export interface ResponsesRequest {
   model: string;
-  messages: OpenAIMessage[];
-  tools?: ToolDefinition[];
-  tool_choice?: "auto" | "none";
+  input: ResponseInputItem[];
+  tools: ToolDefinition[];
+  tool_choice: "auto";
+  reasoning: { effort: ReasoningEffort };
   stream: boolean;
 }
 
-export interface ToolDefinition {
-  type: "function";
-  function: {
-    name: string;
-    description: string;
-    parameters: {
-      type: "object";
-      properties: Record<string, unknown>;
-      required: string[];
+/** Item emitted by the model, as delivered by response.output_item.* events. */
+export interface ResponseOutputItem {
+  type: string;
+  id?: string;
+  call_id?: string;
+  name?: string;
+  arguments?: string;
+  status?: string;
+  action?: {
+    type?: string;
+    query?: string;
+    url?: string;
+  };
+}
+
+export interface ResponseStreamEvent {
+  type: string;
+  delta?: string;
+  item?: ResponseOutputItem;
+  message?: string;
+  code?: string;
+  response?: {
+    status?: string;
+    error?: {
+      message?: string;
+      code?: string;
     };
   };
 }


### PR DESCRIPTION
Emerald had drifted into a generic OpenAI-compatible client (custom base URL, free-form model ID, provider profiles). This brings it back to a dedicated OpenAI Responses API implementation.

## Responses API only

- All traffic goes to `https://api.openai.com/v1/responses`. The Chat Completions request/response shape is gone.
- `MessageBuilder` now emits Responses input items: `input_text` / `input_image` content parts instead of `text` / `image_url`.
- Local tools round-trip as `function_call` / `function_call_output` items, and `StreamProcessor` consumes `response.output_text.delta` and `response.output_item.done` events instead of chat completion deltas. When a stream ends with pending function calls, `onComplete` is deferred until the follow-up request has streamed its answer.
- The title generator uses the same endpoint and reads the text out of the `output` array.

## Fixed model and reasoning effort

- `src/lib/openai/constants.ts` pins the endpoint, `gpt-5.6-luna`, and `reasoning: { effort: "max" }` — the highest effort level GPT-5.6 supports, set through the Responses API's `reasoning.effort` field.
- The base URL, model and provider profile settings are removed from `useSettings`, storage and the settings drawer. The only API setting left is the OpenAI API key.

## Web search

- The Brave Search function tool and its API key setting are removed.
- OpenAI's hosted `web_search` tool is enabled on every request (`web_search`, not the legacy `web_search_preview`). Searches run server side, and completed `web_search_call` items are surfaced as tool activity so they show up in exported conversations.

## Verification

`tsc --noEmit`, `vitest run` (16 files, 146 tests) and both `build:chrome` and `build:firefox` pass.