### PR TITLE
Let the chat UI switch between Sol, Terra and Luna

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ AI assistant browser extension built on the OpenAI Responses API. Supports Chrom
 
 ## Features
 
-- Chat with `gpt-5.6-luna` at `max` reasoning effort
+- Chat with GPT-5.6 Sol (`gpt-5.6-sol`), Terra (`gpt-5.6-terra`) or Luna (`gpt-5.6-luna`), switchable from the chat UI
+- Reasoning effort selectable from the chat UI (`none`, `low`, `medium`, `high`, `xhigh`, `max`)
 - Web search through OpenAI's built-in `web_search` tool
 - Screen capture and image analysis
 - Page context integration
@@ -27,7 +28,9 @@ Load `dist/firefox/manifest.json` as a temporary add-on from `about:debugging#/r
 
 ## Configuration
 
-Set your OpenAI API key in the extension settings.
+Set your OpenAI API key in the extension settings. The model and the reasoning
+effort are picked above the chat input; both are stored in extension storage, so
+they persist across restarts and apply to every conversation.
 
 ## License
 

--- a/docs/architecture/api-communication.md
+++ b/docs/architecture/api-communication.md
@@ -7,15 +7,21 @@ is designed around **streaming responses**, **tool execution**, and **modular
 responsibility separation**. The architecture supports real-time conversation
 updates while maintaining robust error handling and extensibility.
 
-Fixed configuration lives in `src/lib/openai/constants.ts`:
+The endpoint, the selectable models and the selectable reasoning efforts live in
+`src/lib/openai/constants.ts`:
 
-| Setting          | Value                                 |
-| ---------------- | ------------------------------------- |
-| Endpoint         | `https://api.openai.com/v1/responses` |
-| Model            | `gpt-5.6-luna`                        |
-| Reasoning effort | `max`                                 |
+| Setting           | Value                                           |
+| ----------------- | ----------------------------------------------- |
+| Endpoint          | `https://api.openai.com/v1/responses`           |
+| Models            | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`  |
+| Default model     | `gpt-5.6-luna`                                  |
+| Reasoning efforts | `none`, `low`, `medium`, `high`, `xhigh`, `max` |
+| Default effort    | `max`                                           |
 
-The only user-provided API setting is the OpenAI API key.
+The model tiers are surfaced in the UI as Sol, Terra and Luna. The user-provided
+API settings are the OpenAI API key, the model and the reasoning effort; the
+latter two are picked from the chat UI and stored in `chrome.storage.local`
+alongside the other settings.
 
 ## Architecture Components
 
@@ -63,7 +69,7 @@ interface OpenAIClient {
 
 ```json
 {
-  "model": "gpt-5.6-luna",
+  "model": "gpt-5.6-sol",
   "input": [{ "role": "user", "content": "..." }],
   "tools": [
     { "type": "function", "name": "get_current_time" },
@@ -283,15 +289,18 @@ OpenAI function_call → ToolExecutor.execute() → Chrome API Call → function
 ```typescript
 interface OpenAIClientConfig {
   apiKey: string; // Required: OpenAI API authentication
+  model?: ModelId; // Defaults to gpt-5.6-luna
+  reasoningEffort?: ReasoningEffort; // Defaults to max
 }
 ```
 
-Everything else is fixed: model, endpoint, reasoning effort and tools are
-compiled in, so there is no provider, model or endpoint selection to configure.
+The endpoint and the tools are compiled in, so there is no provider or endpoint
+selection to configure.
 
 ### 2. Runtime Configuration
 
 - API key validation
+- Model and reasoning effort selection
 - System prompt
 - Conversation storage (S3 / MinIO) settings
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -22,7 +22,7 @@ Emerald follows a **modular, layered architecture** that separates concerns and 
 ### 1. UI Layer (`src/components/`)
 
 - **Responsibility**: User interface and user interactions
-- **Key Components**: ChatArea, InputArea, ThreadList, ImageSelector
+- **Key Components**: ChatArea, InputArea, ModelSelector, ThreadList, ImageSelector
 - **Pattern**: Presentational components with minimal business logic
 - **Communication**: Props down, events up
 
@@ -47,8 +47,10 @@ OpenAIClient
 └── MessageBuilder     # Converts to Responses API input items
 ```
 
-The client talks to the OpenAI Responses API only. The model, the endpoint and
-the reasoning effort are fixed in `src/lib/openai/constants.ts`.
+The client talks to the OpenAI Responses API only. The endpoint, the selectable
+models and the selectable reasoning efforts are declared in
+`src/lib/openai/constants.ts`; the active model and reasoning effort come from
+the settings, which the user changes through `ModelSelector`.
 
 #### Tool System (`src/lib/tools/`)
 

--- a/src/components/ApiKeySettings.tsx
+++ b/src/components/ApiKeySettings.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import { useSettings } from "../hooks/useSettings";
-import { MODEL, REASONING_EFFORT } from "../lib/openai/constants";
+import { modelLabel } from "../lib/openai/constants";
 
 const ApiKeySettings: React.FC = () => {
   const { settings, loading, saveSettings } = useSettings();
@@ -111,8 +111,9 @@ const ApiKeySettings: React.FC = () => {
       />
 
       <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-        Model: {MODEL} (reasoning effort: {REASONING_EFFORT}). Web search is
-        handled by the built-in OpenAI tool.
+        Model: {modelLabel(settings.model)} ({settings.model}, reasoning effort:{" "}
+        {settings.reasoningEffort}). Pick the model and the reasoning effort
+        above the chat input. Web search is handled by the built-in OpenAI tool.
       </Typography>
 
       <TextField

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
+import { useSettings } from "../hooks/useSettings";
+import { ReasoningEffort } from "../types/openai";
+import { MODELS, REASONING_EFFORTS, ModelId } from "../lib/openai/constants";
+
+/**
+ * Chat-level picker for the GPT-5.6 tier and the reasoning effort.
+ * Both values live in the shared settings, so they survive a reload and
+ * apply to every conversation.
+ */
+const ModelSelector: React.FC = () => {
+  const { settings, loading, updateModel, updateReasoningEffort } =
+    useSettings();
+
+  const handleModelChange = (event: SelectChangeEvent) => {
+    updateModel(event.target.value as ModelId);
+  };
+
+  const handleEffortChange = (event: SelectChangeEvent) => {
+    updateReasoningEffort(event.target.value as ReasoningEffort);
+  };
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, mb: 1, flexShrink: 0 }}>
+      <FormControl size="small" sx={{ flex: 1 }} disabled={loading}>
+        <InputLabel id="model-select-label">Model</InputLabel>
+        <Select
+          labelId="model-select-label"
+          label="Model"
+          value={settings.model}
+          onChange={handleModelChange}
+        >
+          {MODELS.map((model) => (
+            <MenuItem key={model.id} value={model.id}>
+              {model.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl size="small" sx={{ flex: 1 }} disabled={loading}>
+        <InputLabel id="reasoning-effort-select-label">Reasoning</InputLabel>
+        <Select
+          labelId="reasoning-effort-select-label"
+          label="Reasoning"
+          value={settings.reasoningEffort}
+          onChange={handleEffortChange}
+        >
+          {REASONING_EFFORTS.map((effort) => (
+            <MenuItem key={effort} value={effort}>
+              {effort}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+};
+
+export default ModelSelector;

--- a/src/components/__tests__/ModelSelector.test.tsx
+++ b/src/components/__tests__/ModelSelector.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import ModelSelector from "../ModelSelector";
+import { chromeMock } from "../../test/mocks/chrome";
+
+describe("ModelSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(chromeMock.storage.local.get).mockResolvedValue({});
+    vi.mocked(chromeMock.storage.local.set).mockResolvedValue(undefined);
+  });
+
+  const openSelect = async (name: string) => {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name }));
+    return user;
+  };
+
+  it("shows the stored selection", async () => {
+    vi.mocked(chromeMock.storage.local.get).mockResolvedValue({
+      settings: { model: "gpt-5.6-terra", reasoningEffort: "low" },
+    });
+
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "Model" })).toHaveTextContent(
+        "Terra",
+      );
+    });
+    expect(
+      screen.getByRole("combobox", { name: "Reasoning" }),
+    ).toHaveTextContent("low");
+  });
+
+  it("offers Sol, Terra and Luna", async () => {
+    render(<ModelSelector />);
+    await waitFor(() =>
+      expect(chromeMock.storage.local.get).toHaveBeenCalled(),
+    );
+
+    await openSelect("Model");
+
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual(["Sol", "Terra", "Luna"]);
+  });
+
+  it("persists a model change", async () => {
+    render(<ModelSelector />);
+    await waitFor(() =>
+      expect(chromeMock.storage.local.get).toHaveBeenCalled(),
+    );
+
+    const user = await openSelect("Model");
+    await user.click(screen.getByRole("option", { name: "Sol" }));
+
+    await waitFor(() => {
+      expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+        settings: expect.objectContaining({ model: "gpt-5.6-sol" }),
+      });
+    });
+  });
+
+  it("persists a reasoning effort change", async () => {
+    render(<ModelSelector />);
+    await waitFor(() =>
+      expect(chromeMock.storage.local.get).toHaveBeenCalled(),
+    );
+
+    const user = await openSelect("Reasoning");
+    await user.click(screen.getByRole("option", { name: "medium" }));
+
+    await waitFor(() => {
+      expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+        settings: expect.objectContaining({ reasoningEffort: "medium" }),
+      });
+    });
+  });
+});

--- a/src/hooks/__tests__/useApi.test.ts
+++ b/src/hooks/__tests__/useApi.test.ts
@@ -9,6 +9,8 @@ vi.mock("../useSettings", () => ({
     settings: {
       openaiApiKey: "sk-test-key-123",
       systemPrompt: "You are a helpful AI assistant for testing.",
+      model: "gpt-5.6-terra",
+      reasoningEffort: "high",
     },
     loading: false,
     updateApiKey: vi.fn(),
@@ -111,6 +113,8 @@ describe("useApi", () => {
 
     expect(OpenAIClient).toHaveBeenCalledWith({
       apiKey: "sk-test-key-123",
+      model: "gpt-5.6-terra",
+      reasoningEffort: "high",
     });
 
     expect(MessageBuilder).toHaveBeenCalled();

--- a/src/hooks/__tests__/useSettings.test.ts
+++ b/src/hooks/__tests__/useSettings.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useSettings } from "../useSettings";
-import { chromeMock } from "../../test/mocks/chrome";
+import { chromeMock, emitStorageChange } from "../../test/mocks/chrome";
 
 describe("useSettings", () => {
   beforeEach(() => {
@@ -23,6 +23,81 @@ describe("useSettings", () => {
     expect(result.current.settings.openaiApiKey).toBe("");
     expect(result.current.settings.systemPrompt).toContain("Emerald");
     expect(result.current.settings.s3Region).toBe("us-east-1");
+    expect(result.current.settings.model).toBe("gpt-5.6-luna");
+    expect(result.current.settings.reasoningEffort).toBe("max");
+  });
+
+  it("restores the stored model and reasoning effort", async () => {
+    vi.mocked(chromeMock.storage.local.get).mockResolvedValueOnce({
+      settings: { model: "gpt-5.6-sol", reasoningEffort: "medium" },
+    });
+
+    const { result } = renderHook(() => useSettings());
+    await waitLoaded(result);
+
+    expect(result.current.settings.model).toBe("gpt-5.6-sol");
+    expect(result.current.settings.reasoningEffort).toBe("medium");
+  });
+
+  it("falls back to the defaults for unknown stored values", async () => {
+    vi.mocked(chromeMock.storage.local.get).mockResolvedValueOnce({
+      settings: { model: "gpt-4o", reasoningEffort: "ludicrous" },
+    });
+
+    const { result } = renderHook(() => useSettings());
+    await waitLoaded(result);
+
+    expect(result.current.settings.model).toBe("gpt-5.6-luna");
+    expect(result.current.settings.reasoningEffort).toBe("max");
+  });
+
+  it("persists the model and the reasoning effort", async () => {
+    const { result } = renderHook(() => useSettings());
+    await waitLoaded(result);
+
+    await act(async () => {
+      await result.current.updateModel("gpt-5.6-terra");
+    });
+    await act(async () => {
+      await result.current.updateReasoningEffort("high");
+    });
+
+    expect(result.current.settings.model).toBe("gpt-5.6-terra");
+    expect(result.current.settings.reasoningEffort).toBe("high");
+    expect(chromeMock.storage.local.set).toHaveBeenLastCalledWith({
+      settings: expect.objectContaining({
+        model: "gpt-5.6-terra",
+        reasoningEffort: "high",
+      }),
+    });
+  });
+
+  it("picks up settings written elsewhere", async () => {
+    const { result } = renderHook(() => useSettings());
+    await waitLoaded(result);
+
+    act(() => {
+      emitStorageChange({
+        settings: { newValue: { model: "gpt-5.6-sol" } },
+      });
+    });
+
+    expect(result.current.settings.model).toBe("gpt-5.6-sol");
+    expect(result.current.settings.s3Region).toBe("us-east-1");
+  });
+
+  it("ignores changes from other storage areas", async () => {
+    const { result } = renderHook(() => useSettings());
+    await waitLoaded(result);
+
+    act(() => {
+      emitStorageChange(
+        { settings: { newValue: { model: "gpt-5.6-sol" } } },
+        "session",
+      );
+    });
+
+    expect(result.current.settings.model).toBe("gpt-5.6-luna");
   });
 
   it("merges stored settings over the defaults", async () => {

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -36,6 +36,8 @@ export const useApi = () => {
 
       const client = new OpenAIClient({
         apiKey: settings.openaiApiKey,
+        model: settings.model,
+        reasoningEffort: settings.reasoningEffort,
       });
 
       const messageBuilder = new MessageBuilder();

--- a/src/hooks/useConversationExport.ts
+++ b/src/hooks/useConversationExport.ts
@@ -50,7 +50,11 @@ export const useConversationExport = () => {
 
     try {
       const title = await generateConversationTitle(
-        { apiKey: settings.openaiApiKey },
+        {
+          apiKey: settings.openaiApiKey,
+          model: settings.model,
+          reasoningEffort: settings.reasoningEffort,
+        },
         messages,
       );
       const html = buildConversationHtml(messages, {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,8 +1,18 @@
 import { useState, useEffect } from "react";
+import { ReasoningEffort } from "../types/openai";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_REASONING_EFFORT,
+  ModelId,
+  isModelId,
+  isReasoningEffort,
+} from "../lib/openai/constants";
 
 interface Settings {
   openaiApiKey: string;
   systemPrompt: string;
+  model: ModelId;
+  reasoningEffort: ReasoningEffort;
   s3Endpoint: string;
   s3Region: string;
   s3Bucket: string;
@@ -17,6 +27,8 @@ const DEFAULT_SETTINGS: Settings = {
   openaiApiKey: "",
   systemPrompt:
     "You are a helpful AI assistant integrated into a Chrome extension called Emerald. You can help users with various tasks while they browse the web. When users provide page content, use it to give more contextual and relevant responses. Use the built-in web search tool whenever up-to-date or external information would help, and cite the source URLs as Markdown links. Be concise but helpful, and adapt your responses to the context of what the user is doing.",
+  model: DEFAULT_MODEL,
+  reasoningEffort: DEFAULT_REASONING_EFFORT,
   s3Endpoint: "",
   s3Region: "us-east-1",
   s3Bucket: "",
@@ -29,6 +41,17 @@ const DEFAULT_SETTINGS: Settings = {
 
 export type { Settings };
 
+/** Drop model and reasoning effort values that the API no longer accepts. */
+function sanitize(settings: Settings): Settings {
+  return {
+    ...settings,
+    model: isModelId(settings.model) ? settings.model : DEFAULT_MODEL,
+    reasoningEffort: isReasoningEffort(settings.reasoningEffort)
+      ? settings.reasoningEffort
+      : DEFAULT_REASONING_EFFORT,
+  };
+}
+
 export const useSettings = () => {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [loading, setLoading] = useState(true);
@@ -37,11 +60,27 @@ export const useSettings = () => {
     loadSettings();
   }, []);
 
+  // Every hook instance keeps its own copy, so mirror writes made elsewhere
+  // (e.g. the model selector) into this one.
+  useEffect(() => {
+    const handleChange = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string,
+    ) => {
+      if (areaName !== "local" || !changes.settings) return;
+      const stored = changes.settings.newValue as Partial<Settings> | undefined;
+      setSettings(sanitize({ ...DEFAULT_SETTINGS, ...stored }));
+    };
+
+    chrome.storage.onChanged.addListener(handleChange);
+    return () => chrome.storage.onChanged.removeListener(handleChange);
+  }, []);
+
   const loadSettings = async () => {
     try {
       const result = await chrome.storage.local.get(["settings"]);
       if (result.settings) {
-        setSettings({ ...DEFAULT_SETTINGS, ...result.settings });
+        setSettings(sanitize({ ...DEFAULT_SETTINGS, ...result.settings }));
       }
     } catch (error) {
       console.error("Failed to load settings:", error);
@@ -68,11 +107,21 @@ export const useSettings = () => {
     await saveSettings({ systemPrompt });
   };
 
+  const updateModel = async (model: ModelId) => {
+    await saveSettings({ model });
+  };
+
+  const updateReasoningEffort = async (reasoningEffort: ReasoningEffort) => {
+    await saveSettings({ reasoningEffort });
+  };
+
   return {
     settings,
     loading,
     updateApiKey,
     updateSystemPrompt,
+    updateModel,
+    updateReasoningEffort,
     saveSettings,
   };
 };

--- a/src/lib/openai/__tests__/client.test.ts
+++ b/src/lib/openai/__tests__/client.test.ts
@@ -78,7 +78,7 @@ describe("OpenAIClient", () => {
       expect(onComplete).toHaveBeenCalled();
     });
 
-    it("should always request gpt-5.6-luna with max reasoning effort", async () => {
+    it("should fall back to gpt-5.6-luna with max reasoning effort", async () => {
       globalThis.fetch = vi
         .fn()
         .mockResolvedValue(createMockResponse([textDelta("test")]));
@@ -94,6 +94,56 @@ describe("OpenAIClient", () => {
       expect(requestBody.input).toEqual(mockInput);
       expect(requestBody.tool_choice).toBe("auto");
       expect(requestBody.stream).toBe(true);
+    });
+
+    it("should request the configured model and reasoning effort", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(createMockResponse([textDelta("test")]));
+
+      const configured = new OpenAIClient({
+        apiKey: mockApiKey,
+        model: "gpt-5.6-sol",
+        reasoningEffort: "medium",
+      });
+      await configured.sendMessage(mockInput, {});
+
+      const requestBody = JSON.parse(
+        (globalThis.fetch as any).mock.calls[0][1].body,
+      );
+
+      expect(requestBody.model).toBe("gpt-5.6-sol");
+      expect(requestBody.reasoning).toEqual({ effort: "medium" });
+    });
+
+    it("should keep the configured model on the tool-output follow-up", async () => {
+      const firstResponse = createMockResponse([
+        functionCallDone("call_1", "get_current_time", "{}"),
+        'data: {"type":"response.completed"}\n',
+      ]);
+      const secondResponse = createMockResponse([
+        textDelta("It is late."),
+        'data: {"type":"response.completed"}\n',
+      ]);
+
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(firstResponse)
+        .mockResolvedValueOnce(secondResponse);
+
+      const configured = new OpenAIClient({
+        apiKey: mockApiKey,
+        model: "gpt-5.6-terra",
+        reasoningEffort: "high",
+      });
+      await configured.sendMessage(mockInput, {});
+
+      const followUpBody = JSON.parse(
+        (globalThis.fetch as any).mock.calls[1][1].body,
+      );
+
+      expect(followUpBody.model).toBe("gpt-5.6-terra");
+      expect(followUpBody.reasoning).toEqual({ effort: "high" });
     });
 
     it("should offer the local function tool and the built-in web search", async () => {

--- a/src/lib/openai/__tests__/title-generator.test.ts
+++ b/src/lib/openai/__tests__/title-generator.test.ts
@@ -61,6 +61,23 @@ describe("generateConversationTitle", () => {
     expect(body.stream).toBe(false);
   });
 
+  it("uses the configured model and reasoning effort", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(mockResponse("A title"));
+
+    await generateConversationTitle(
+      { apiKey: "sk-test", model: "gpt-5.6-sol", reasoningEffort: "low" },
+      [makeMessage("user", "hello")],
+    );
+
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body.model).toBe("gpt-5.6-sol");
+    expect(body.reasoning).toEqual({ effort: "low" });
+  });
+
   it("returns null when there is no usable content", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
 

--- a/src/lib/openai/client.ts
+++ b/src/lib/openai/client.ts
@@ -2,24 +2,36 @@ import {
   ApiError,
   FunctionCallItem,
   FunctionCallOutputItem,
+  ReasoningEffort,
   ResponseInputItem,
   ResponsesRequest,
 } from "../../types/openai";
-import { MODEL, REASONING_EFFORT, RESPONSES_URL } from "./constants";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_REASONING_EFFORT,
+  ModelId,
+  RESPONSES_URL,
+} from "./constants";
 import { StreamProcessor, StreamCallbacks } from "./stream-processor";
 import { ToolExecutor, getAvailableTools } from "../tools/executor";
 
 export interface OpenAIClientConfig {
   apiKey: string;
+  model?: ModelId;
+  reasoningEffort?: ReasoningEffort;
 }
 
 export class OpenAIClient {
   private apiKey: string;
+  private model: ModelId;
+  private reasoningEffort: ReasoningEffort;
   private streamProcessor: StreamProcessor;
   private toolExecutor: ToolExecutor;
 
   constructor(config: OpenAIClientConfig) {
     this.apiKey = config.apiKey;
+    this.model = config.model ?? DEFAULT_MODEL;
+    this.reasoningEffort = config.reasoningEffort ?? DEFAULT_REASONING_EFFORT;
     this.streamProcessor = new StreamProcessor();
     this.toolExecutor = new ToolExecutor();
   }
@@ -56,11 +68,11 @@ export class OpenAIClient {
 
   private buildRequest(input: ResponseInputItem[]): ResponsesRequest {
     return {
-      model: MODEL,
+      model: this.model,
       input,
       tools: getAvailableTools(),
       tool_choice: "auto",
-      reasoning: { effort: REASONING_EFFORT },
+      reasoning: { effort: this.reasoningEffort },
       stream: true,
     };
   }

--- a/src/lib/openai/constants.ts
+++ b/src/lib/openai/constants.ts
@@ -2,6 +2,49 @@ import { ReasoningEffort } from "../../types/openai";
 
 export const RESPONSES_URL = "https://api.openai.com/v1/responses";
 
-export const MODEL = "gpt-5.6-luna";
+/** Model IDs of the GPT-5.6 capability tiers exposed by the Responses API. */
+export const MODEL_IDS = [
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+] as const;
 
-export const REASONING_EFFORT: ReasoningEffort = "max";
+export type ModelId = (typeof MODEL_IDS)[number];
+
+export interface ModelOption {
+  id: ModelId;
+  /** Tier name used in the UI. */
+  label: string;
+}
+
+export const MODELS: ModelOption[] = [
+  { id: "gpt-5.6-sol", label: "Sol" },
+  { id: "gpt-5.6-terra", label: "Terra" },
+  { id: "gpt-5.6-luna", label: "Luna" },
+];
+
+export const DEFAULT_MODEL: ModelId = "gpt-5.6-luna";
+
+/** Reasoning efforts accepted by every GPT-5.6 tier. */
+export const REASONING_EFFORTS: ReasoningEffort[] = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "max";
+
+export function isModelId(value: unknown): value is ModelId {
+  return MODEL_IDS.includes(value as ModelId);
+}
+
+export function isReasoningEffort(value: unknown): value is ReasoningEffort {
+  return REASONING_EFFORTS.includes(value as ReasoningEffort);
+}
+
+export function modelLabel(id: ModelId): string {
+  return MODELS.find((model) => model.id === id)?.label ?? id;
+}

--- a/src/lib/openai/title-generator.ts
+++ b/src/lib/openai/title-generator.ts
@@ -1,8 +1,16 @@
 import { Message } from "../../types";
-import { MODEL, REASONING_EFFORT, RESPONSES_URL } from "./constants";
+import { ReasoningEffort } from "../../types/openai";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_REASONING_EFFORT,
+  ModelId,
+  RESPONSES_URL,
+} from "./constants";
 
 export interface TitleGeneratorConfig {
   apiKey: string;
+  model?: ModelId;
+  reasoningEffort?: ReasoningEffort;
 }
 
 const MAX_CHARS_PER_MESSAGE = 600;
@@ -64,8 +72,10 @@ export async function generateConversationTitle(
         Authorization: `Bearer ${config.apiKey}`,
       },
       body: JSON.stringify({
-        model: MODEL,
-        reasoning: { effort: REASONING_EFFORT },
+        model: config.model ?? DEFAULT_MODEL,
+        reasoning: {
+          effort: config.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
+        },
         stream: false,
         input: [
           {

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -20,6 +20,7 @@ import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import ChatArea from "../components/ChatArea";
 import InputArea from "../components/InputArea";
 import ApiKeySettings from "../components/ApiKeySettings";
+import ModelSelector from "../components/ModelSelector";
 import { Message, ImageData, PageContent, ToolInteraction } from "../types";
 import { useApi } from "../hooks/useApi";
 import { useChatThread } from "../hooks/useChatThread";
@@ -226,6 +227,7 @@ const App: React.FC = () => {
           }}
         >
           <ChatArea messages={messages} error={error} />
+          <ModelSelector />
           <InputArea
             onSendMessage={handleSendMessage}
             disabled={messages.some((m) => m.status === "streaming")}

--- a/src/test/mocks/chrome.ts
+++ b/src/test/mocks/chrome.ts
@@ -24,10 +24,24 @@ interface RuntimeMessage {
   [key: string]: any;
 }
 
+interface StorageChange {
+  oldValue?: any;
+  newValue?: any;
+}
+
+type StorageChangedListener = (
+  changes: Record<string, StorageChange>,
+  areaName: string,
+) => void;
+
 interface ChromeMock {
   storage: {
     local: StorageArea;
     session: StorageArea;
+    onChanged: {
+      addListener: (listener: StorageChangedListener) => void;
+      removeListener: (listener: StorageChangedListener) => void;
+    };
   };
   tabs: {
     query: (queryInfo: {
@@ -70,6 +84,16 @@ interface ChromeMock {
 
 const mockStorage: Record<string, any> = {};
 const mockSessionStorage: Record<string, any> = {};
+
+const storageListeners = new Set<StorageChangedListener>();
+
+/** Deliver a storage change to everything listening on chrome.storage.onChanged. */
+const emitStorageChange = (
+  changes: Record<string, StorageChange>,
+  areaName = "local",
+) => {
+  storageListeners.forEach((listener) => listener(changes, areaName));
+};
 
 const createStorageArea = (store: Record<string, any>): StorageArea => ({
   get: vi.fn().mockImplementation(async (key) => {
@@ -127,6 +151,14 @@ const chromeMock: ChromeMock = {
   storage: {
     local: createStorageArea(mockStorage),
     session: createStorageArea(mockSessionStorage),
+    onChanged: {
+      addListener: vi.fn().mockImplementation((listener) => {
+        storageListeners.add(listener);
+      }),
+      removeListener: vi.fn().mockImplementation((listener) => {
+        storageListeners.delete(listener);
+      }),
+    },
   },
   tabs: {
     query: vi.fn().mockResolvedValue(mockTabs),
@@ -156,5 +188,5 @@ const chromeMock: ChromeMock = {
 
 (globalThis as any).chrome = chromeMock;
 
-export { chromeMock };
+export { chromeMock, emitStorageChange };
 export default chromeMock;


### PR DESCRIPTION
## Summary

The extension was pinned to `gpt-5.6-luna` at `max` reasoning effort. This adds a picker above the chat input for both the GPT-5.6 tier and the reasoning effort, and persists the choice.

## Model IDs

Verified against the OpenAI API model docs — the three GPT-5.6 tiers are:

| Tier  | Model ID         |
| ----- | ---------------- |
| Sol   | `gpt-5.6-sol`    |
| Terra | `gpt-5.6-terra`  |
| Luna  | `gpt-5.6-luna`   |

All three accept the same reasoning efforts: `none`, `low`, `medium`, `high`, `xhigh`, `max`.

## Changes

- `src/lib/openai/constants.ts` now declares the selectable models and reasoning efforts (with type guards) instead of a single fixed `MODEL` / `REASONING_EFFORT` pair. Defaults stay `gpt-5.6-luna` / `max`, so existing installs keep their current behaviour.
- `OpenAIClient` and the conversation title generator take the model and the reasoning effort from their config, falling back to the defaults. The tool-output follow-up request keeps the same model.
- `useSettings` stores `model` and `reasoningEffort` in `chrome.storage.local` next to the other settings, so the choice survives a restart and applies to every conversation. Unknown stored values fall back to the defaults.
- `useSettings` also listens on `chrome.storage.onChanged`, so a change made in the selector reaches the other hook instances (`useApi`, the settings drawer) without a reload.
- New `ModelSelector` component, rendered between the chat area and the input.
- Settings drawer now reports the active model and reasoning effort instead of hardcoded values.
- README and architecture docs updated.

## Testing

- `pnpm test` — 158 tests pass, including new coverage for the selector, the settings persistence and the client/title-generator request payloads.
- `pnpm build` — both Chrome and Firefox targets build.
- Rendered the selector in a browser at side-panel width: both controls fit on one row, the dropdown lists Sol / Terra / Luna and selecting a tier updates the control.