### PR TITLE
Collapse the model and reasoning pickers behind a toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Load `dist/firefox/manifest.json` as a temporary add-on from `about:debugging#/r
 ## Configuration
 
 Set your OpenAI API key in the extension settings. The model and the reasoning
-effort are picked above the chat input; both are stored in extension storage, so
-they persist across restarts and apply to every conversation.
+effort are picked above the chat input, behind a summary button that expands the
+pickers when you need them. The selection and the expanded state are stored in
+extension storage, so they persist across restarts and apply to every
+conversation.
 
 ## License
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -50,7 +50,9 @@ OpenAIClient
 The client talks to the OpenAI Responses API only. The endpoint, the selectable
 models and the selectable reasoning efforts are declared in
 `src/lib/openai/constants.ts`; the active model and reasoning effort come from
-the settings, which the user changes through `ModelSelector`.
+the settings, which the user changes through `ModelSelector`. That component
+keeps its pickers collapsed behind a summary button and stores the expanded
+state in the settings as well.
 
 #### Tool System (`src/lib/tools/`)
 

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -1,24 +1,44 @@
 import React from "react";
 import {
   Box,
+  Button,
+  Collapse,
   FormControl,
   InputLabel,
   MenuItem,
   Select,
   SelectChangeEvent,
+  Tooltip,
 } from "@mui/material";
+import TuneIcon from "@mui/icons-material/Tune";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useSettings } from "../hooks/useSettings";
 import { ReasoningEffort } from "../types/openai";
-import { MODELS, REASONING_EFFORTS, ModelId } from "../lib/openai/constants";
+import {
+  MODELS,
+  REASONING_EFFORTS,
+  ModelId,
+  modelLabel,
+} from "../lib/openai/constants";
 
 /**
  * Chat-level picker for the GPT-5.6 tier and the reasoning effort.
- * Both values live in the shared settings, so they survive a reload and
- * apply to every conversation.
+ * The pickers stay collapsed behind a summary button so they only take up
+ * room while they are being used. Selection and expanded state both live in
+ * the shared settings, so they survive a reload and apply to every
+ * conversation.
  */
 const ModelSelector: React.FC = () => {
-  const { settings, loading, updateModel, updateReasoningEffort } =
-    useSettings();
+  const {
+    settings,
+    loading,
+    updateModel,
+    updateReasoningEffort,
+    updateModelSelectorOpen,
+  } = useSettings();
+
+  const open = settings.modelSelectorOpen;
 
   const handleModelChange = (event: SelectChangeEvent) => {
     updateModel(event.target.value as ModelId);
@@ -29,38 +49,65 @@ const ModelSelector: React.FC = () => {
   };
 
   return (
-    <Box sx={{ display: "flex", gap: 1, mb: 1, flexShrink: 0 }}>
-      <FormControl size="small" sx={{ flex: 1 }} disabled={loading}>
-        <InputLabel id="model-select-label">Model</InputLabel>
-        <Select
-          labelId="model-select-label"
-          label="Model"
-          value={settings.model}
-          onChange={handleModelChange}
-        >
-          {MODELS.map((model) => (
-            <MenuItem key={model.id} value={model.id}>
-              {model.label}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+    <Box sx={{ mb: 1, flexShrink: 0 }}>
+      <Tooltip
+        title={open ? "Hide model settings" : "Change model and reasoning"}
+      >
+        {/* The span keeps the tooltip working while the button is disabled. */}
+        <span>
+          <Button
+            size="small"
+            color="inherit"
+            disabled={loading}
+            onClick={() => updateModelSelectorOpen(!open)}
+            startIcon={<TuneIcon fontSize="small" />}
+            endIcon={open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            aria-expanded={open}
+            aria-controls="model-selector-panel"
+            sx={{ textTransform: "none", color: "text.secondary" }}
+          >
+            {`${modelLabel(settings.model)} · ${settings.reasoningEffort}`}
+          </Button>
+        </span>
+      </Tooltip>
 
-      <FormControl size="small" sx={{ flex: 1 }} disabled={loading}>
-        <InputLabel id="reasoning-effort-select-label">Reasoning</InputLabel>
-        <Select
-          labelId="reasoning-effort-select-label"
-          label="Reasoning"
-          value={settings.reasoningEffort}
-          onChange={handleEffortChange}
-        >
-          {REASONING_EFFORTS.map((effort) => (
-            <MenuItem key={effort} value={effort}>
-              {effort}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <Collapse in={open} unmountOnExit>
+        <Box id="model-selector-panel" sx={{ display: "flex", gap: 1, mt: 1 }}>
+          <FormControl size="small" sx={{ flex: 1 }} disabled={loading}>
+            <InputLabel id="model-select-label">Model</InputLabel>
+            <Select
+              labelId="model-select-label"
+              label="Model"
+              value={settings.model}
+              onChange={handleModelChange}
+            >
+              {MODELS.map((model) => (
+                <MenuItem key={model.id} value={model.id}>
+                  {model.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ flex: 1 }} disabled={loading}>
+            <InputLabel id="reasoning-effort-select-label">
+              Reasoning
+            </InputLabel>
+            <Select
+              labelId="reasoning-effort-select-label"
+              label="Reasoning"
+              value={settings.reasoningEffort}
+              onChange={handleEffortChange}
+            >
+              {REASONING_EFFORTS.map((effort) => (
+                <MenuItem key={effort} value={effort}>
+                  {effort}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+      </Collapse>
     </Box>
   );
 };

--- a/src/components/__tests__/ModelSelector.test.tsx
+++ b/src/components/__tests__/ModelSelector.test.tsx
@@ -11,15 +11,95 @@ describe("ModelSelector", () => {
     vi.mocked(chromeMock.storage.local.set).mockResolvedValue(undefined);
   });
 
-  const openSelect = async (name: string) => {
+  const toggleButton = () =>
+    screen.getByRole("button", { name: /Luna|Sol|Terra/ });
+
+  /** Render, wait for the stored settings, then expand the pickers. */
+  const renderExpanded = async () => {
+    render(<ModelSelector />);
+    await waitFor(() =>
+      expect(chromeMock.storage.local.get).toHaveBeenCalled(),
+    );
+
     const user = userEvent.setup();
-    await user.click(screen.getByRole("combobox", { name }));
+    await user.click(toggleButton());
+    await screen.findByRole("combobox", { name: "Model" });
     return user;
   };
 
-  it("shows the stored selection", async () => {
+  const openSelect = async (
+    user: ReturnType<typeof userEvent.setup>,
+    name: string,
+  ) => {
+    await user.click(screen.getByRole("combobox", { name }));
+  };
+
+  it("keeps the pickers collapsed by default", async () => {
+    render(<ModelSelector />);
+    await waitFor(() =>
+      expect(chromeMock.storage.local.get).toHaveBeenCalled(),
+    );
+
+    expect(screen.queryByRole("combobox", { name: "Model" })).toBeNull();
+    expect(toggleButton()).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("summarises the current selection on the toggle", async () => {
     vi.mocked(chromeMock.storage.local.get).mockResolvedValue({
       settings: { model: "gpt-5.6-terra", reasoningEffort: "low" },
+    });
+
+    render(<ModelSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Terra/ })).toHaveTextContent(
+        "Terra · low",
+      );
+    });
+  });
+
+  it("restores the stored expanded state", async () => {
+    vi.mocked(chromeMock.storage.local.get).mockResolvedValue({
+      settings: { modelSelectorOpen: true },
+    });
+
+    render(<ModelSelector />);
+
+    expect(
+      await screen.findByRole("combobox", { name: "Model" }),
+    ).toBeInTheDocument();
+  });
+
+  it("persists the expanded state on toggle", async () => {
+    await renderExpanded();
+
+    await waitFor(() => {
+      expect(chromeMock.storage.local.set).toHaveBeenCalledWith({
+        settings: expect.objectContaining({ modelSelectorOpen: true }),
+      });
+    });
+  });
+
+  it("collapses again after a second click", async () => {
+    const user = await renderExpanded();
+
+    await user.click(toggleButton());
+
+    await waitFor(() =>
+      expect(screen.queryByRole("combobox", { name: "Model" })).toBeNull(),
+    );
+    expect(chromeMock.storage.local.set).toHaveBeenLastCalledWith({
+      settings: expect.objectContaining({ modelSelectorOpen: false }),
+    });
+  });
+
+  it("shows the stored selection", async () => {
+    vi.mocked(chromeMock.storage.local.get).mockResolvedValue({
+      settings: {
+        model: "gpt-5.6-terra",
+        reasoningEffort: "low",
+        modelSelectorOpen: true,
+      },
     });
 
     render(<ModelSelector />);
@@ -35,12 +115,9 @@ describe("ModelSelector", () => {
   });
 
   it("offers Sol, Terra and Luna", async () => {
-    render(<ModelSelector />);
-    await waitFor(() =>
-      expect(chromeMock.storage.local.get).toHaveBeenCalled(),
-    );
+    const user = await renderExpanded();
 
-    await openSelect("Model");
+    await openSelect(user, "Model");
 
     expect(
       screen.getAllByRole("option").map((option) => option.textContent),
@@ -48,12 +125,9 @@ describe("ModelSelector", () => {
   });
 
   it("persists a model change", async () => {
-    render(<ModelSelector />);
-    await waitFor(() =>
-      expect(chromeMock.storage.local.get).toHaveBeenCalled(),
-    );
+    const user = await renderExpanded();
 
-    const user = await openSelect("Model");
+    await openSelect(user, "Model");
     await user.click(screen.getByRole("option", { name: "Sol" }));
 
     await waitFor(() => {
@@ -64,12 +138,9 @@ describe("ModelSelector", () => {
   });
 
   it("persists a reasoning effort change", async () => {
-    render(<ModelSelector />);
-    await waitFor(() =>
-      expect(chromeMock.storage.local.get).toHaveBeenCalled(),
-    );
+    const user = await renderExpanded();
 
-    const user = await openSelect("Reasoning");
+    await openSelect(user, "Reasoning");
     await user.click(screen.getByRole("option", { name: "medium" }));
 
     await waitFor(() => {

--- a/src/hooks/__tests__/useSettings.test.ts
+++ b/src/hooks/__tests__/useSettings.test.ts
@@ -25,6 +25,7 @@ describe("useSettings", () => {
     expect(result.current.settings.s3Region).toBe("us-east-1");
     expect(result.current.settings.model).toBe("gpt-5.6-luna");
     expect(result.current.settings.reasoningEffort).toBe("max");
+    expect(result.current.settings.modelSelectorOpen).toBe(false);
   });
 
   it("restores the stored model and reasoning effort", async () => {
@@ -70,6 +71,31 @@ describe("useSettings", () => {
         reasoningEffort: "high",
       }),
     });
+  });
+
+  it("persists the model selector expanded state", async () => {
+    const { result } = renderHook(() => useSettings());
+    await waitLoaded(result);
+
+    await act(async () => {
+      await result.current.updateModelSelectorOpen(true);
+    });
+
+    expect(result.current.settings.modelSelectorOpen).toBe(true);
+    expect(chromeMock.storage.local.set).toHaveBeenLastCalledWith({
+      settings: expect.objectContaining({ modelSelectorOpen: true }),
+    });
+  });
+
+  it("restores the stored model selector expanded state", async () => {
+    vi.mocked(chromeMock.storage.local.get).mockResolvedValueOnce({
+      settings: { modelSelectorOpen: true },
+    });
+
+    const { result } = renderHook(() => useSettings());
+    await waitLoaded(result);
+
+    expect(result.current.settings.modelSelectorOpen).toBe(true);
   });
 
   it("picks up settings written elsewhere", async () => {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -13,6 +13,8 @@ interface Settings {
   systemPrompt: string;
   model: ModelId;
   reasoningEffort: ReasoningEffort;
+  /** Whether the chat-level model pickers are expanded. */
+  modelSelectorOpen: boolean;
   s3Endpoint: string;
   s3Region: string;
   s3Bucket: string;
@@ -29,6 +31,7 @@ const DEFAULT_SETTINGS: Settings = {
     "You are a helpful AI assistant integrated into a Chrome extension called Emerald. You can help users with various tasks while they browse the web. When users provide page content, use it to give more contextual and relevant responses. Use the built-in web search tool whenever up-to-date or external information would help, and cite the source URLs as Markdown links. Be concise but helpful, and adapt your responses to the context of what the user is doing.",
   model: DEFAULT_MODEL,
   reasoningEffort: DEFAULT_REASONING_EFFORT,
+  modelSelectorOpen: false,
   s3Endpoint: "",
   s3Region: "us-east-1",
   s3Bucket: "",
@@ -115,6 +118,10 @@ export const useSettings = () => {
     await saveSettings({ reasoningEffort });
   };
 
+  const updateModelSelectorOpen = async (modelSelectorOpen: boolean) => {
+    await saveSettings({ modelSelectorOpen });
+  };
+
   return {
     settings,
     loading,
@@ -122,6 +129,7 @@ export const useSettings = () => {
     updateSystemPrompt,
     updateModel,
     updateReasoningEffort,
+    updateModelSelectorOpen,
     saveSettings,
   };
 };


### PR DESCRIPTION
## Summary

The model and reasoning effort selectors were always visible above the chat input, which crowded the side panel. They now sit behind a compact toggle that is collapsed by default.

- The toggle shows the current selection (e.g. `Luna · max`) with a tune icon, an expand chevron and a tooltip, so the active configuration is readable without expanding.
- Clicking it expands the two selects in a `Collapse`; clicking again folds them away.
- The expanded state is stored in extension settings as `modelSelectorOpen` (default `false`), so it is restored on reload and stays in sync across hook instances via the existing `chrome.storage.onChanged` listener.
- The stored model and reasoning effort values themselves are unchanged.

## Testing

- `pnpm test` — 165 tests pass, including new coverage for the default-collapsed state, the summary label, restoring the stored expanded state, and persisting both expand and collapse.
- `pnpm build` — Chrome and Firefox builds succeed.