### PR TITLE
Add browser agent tools that drive the active tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ AI assistant browser extension built on the OpenAI Responses API. Supports Chrom
 - Chat with GPT-5.6 Sol (`gpt-5.6-sol`), Terra (`gpt-5.6-terra`) or Luna (`gpt-5.6-luna`), switchable from the chat UI
 - Reasoning effort selectable from the chat UI (`none`, `low`, `medium`, `high`, `xhigh`, `max`)
 - Web search through OpenAI's built-in `web_search` tool
+- Browser agent: the assistant reads the DOM of the active tab, lists what it can
+  click, fills forms and navigates on its own, and logs every action in the chat
 - Screen capture and image analysis
 - Page context integration
 - Conversation history
@@ -33,6 +35,20 @@ effort are picked above the chat input, behind a summary button that expands the
 pickers when you need them. The selection and the expanded state are stored in
 extension storage, so they persist across restarts and apply to every
 conversation.
+
+## Browser agent
+
+The assistant can drive the tab the side panel is open on. It reads the page
+structure, lists the links, buttons and form controls it can act on, then clicks,
+types and navigates. There is no headless browser involved: the extension already
+runs in the browser, so the commands execute in the content script of the page.
+
+These tools fire without asking for confirmation, so the assistant can work
+through a task on its own. Every call is written into the chat log — expand the
+"tool actions" chip under an answer to see what ran and what it returned.
+
+Pages without a content script (`chrome://`, `about:`, the extension gallery)
+cannot be driven. See [docs/architecture/browser-agent.md](./docs/architecture/browser-agent.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Emerald is a Chrome extension that provides an AI assistant interface for web br
 
 - **[Architecture Overview](./architecture/overview.md)** - High-level system design and component relationships
 - **[API Communication](./architecture/api-communication.md)** - OpenAI API integration architecture
+- **[Browser Agent](./architecture/browser-agent.md)** - Tools that let the model drive the active tab
 - **[Testing Strategy](./testing/strategy.md)** - Testing approach and guidelines
 - **[Development Workflow](./development/workflow.md)** - Setup, build, and contribution guidelines
 
@@ -34,7 +35,8 @@ src/
 ├── hooks/              # Custom React hooks
 ├── lib/                # Business logic and utilities
 │   ├── openai/         # OpenAI API integration
-│   ├── tools/          # Chrome extension tools
+│   ├── browser-agent/  # Command contract and side-panel bridge to the page
+│   ├── tools/          # Function tools offered to the model
 │   └── message-builder.ts
 ├── types/              # TypeScript type definitions
 ├── utils/              # Utility functions (chatStorage)

--- a/docs/architecture/browser-agent.md
+++ b/docs/architecture/browser-agent.md
@@ -1,0 +1,108 @@
+# Browser Agent
+
+The browser agent lets the model operate the tab the side panel is attached to:
+read its DOM, discover what can be clicked, fill forms and navigate. The tools
+run without asking the user for confirmation, and every call is written into the
+chat log so the operation stays visible.
+
+## No headless browser
+
+Emerald already runs inside the browser it drives, so there is no Playwright or
+Puppeteer dependency and no second browser process. The commands execute in the
+content script of the page under control, which is faster than a remote driver
+and works on pages the user is already signed in to.
+
+The consequence is that the agent can only act on pages a content script can
+reach. Browser-internal pages (`chrome://`, `about:`, the extension gallery)
+have no content script, and the tools report that instead of failing silently.
+
+## Layers
+
+```
+Side panel                          Page
+──────────                          ────
+ToolExecutor
+  └─ browser-tools.ts   command    content.ts
+       └─ bridge.ts  ───────────▶    └─ browser-agent.ts
+                     ◀───────────         (DOM access)
+                        text
+```
+
+- `src/lib/tools/browser-tools.ts` declares the tools and turns model arguments
+  into commands.
+- `src/lib/browser-agent/types.ts` is the command contract shared by both sides.
+- `src/lib/browser-agent/bridge.ts` finds the active tab, relays commands and
+  waits for navigations.
+- `src/content/browser-agent.ts` executes the commands against the real DOM.
+
+Commands answer with plain text, already formatted for the model, so nothing has
+to be re-serialized on the way back.
+
+## Tools
+
+| Tool                    | Purpose                                                      |
+| ----------------------- | ------------------------------------------------------------ |
+| `browser_read_page`     | Title, URL and an indented outline of the visible DOM        |
+| `browser_list_elements` | Indexed list of links, buttons and form controls             |
+| `browser_click`         | Click by index or CSS selector                               |
+| `browser_fill`          | Fill inputs, textareas, selects, checkboxes, contenteditable |
+| `browser_navigate`      | Open a URL and wait for the load to finish                   |
+| `browser_scroll`        | Move by viewport, jump to top or bottom, reveal an element   |
+
+The usual loop is read the page, list the elements, act on an index, then list
+again because the page changed.
+
+## Element indices
+
+`browser_list_elements` rebuilds a registry of the visible interactive elements
+and hands out an index per element. `browser_click`, `browser_fill` and
+`browser_scroll` accept that index, which spares the model from inventing CSS
+selectors for markup it cannot see.
+
+The registry lives in the content script, so a page load discards it. An index
+that no longer resolves, or that points at a detached element, produces an error
+telling the model to list the elements again. Every element line also carries a
+CSS selector, which the tools accept as an alternative to the index and which
+survives a reload.
+
+## Reading the DOM
+
+Raw HTML is mostly noise. `browser_read_page` walks the document and emits one
+line per element, indented by depth:
+
+```
+<div id="main" class="container">
+  <h1> "Example Domain"
+  <p> "This domain is for use in documents."
+  <a href="/more" class="link"> "More information..."
+```
+
+Elements that carry no meaning (`script`, `style`, `svg`, `meta`, …) and
+elements hidden by CSS are skipped, attribute values are shortened, and only the
+element's own text is printed, not its descendants'. The output is capped
+(12000 characters by default) and says so when it is cut short.
+
+## Navigation
+
+A click or a form submit can destroy the content script before it answers. The
+command is therefore answered synchronously, and if the response is lost anyway
+the bridge treats the disconnect as a navigation rather than an error. Either
+way it waits for the tab to finish loading and appends where the page ended up:
+
+```
+Clicked <button> "Log in".
+Navigated to https://example.com/dashboard (Dashboard).
+```
+
+## Logging
+
+`OpenAIClient` reports every executed call through `onToolActivity`, which the
+side panel appends to the streaming message. `ToolActivityLog` renders them
+under a collapsible chip inside the assistant bubble, so an autonomous run can
+be audited after the fact — including the arguments and the returned text.
+
+## Permissions
+
+Driving the page needs `tabs` (to find the active tab and follow its loading
+state) and `host_permissions: <all_urls>` (to message the content script on any
+page). Both are declared in `src/manifest.json` for Chrome and Firefox.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -57,9 +57,18 @@ state in the settings as well.
 #### Tool System (`src/lib/tools/`)
 
 - **ToolExecutor**: Executes the local function tools
-- **Local Tools**: `get_current_time`
+- **Local Tools**: `get_current_time` and the browser agent tools
 - **Hosted Tools**: OpenAI's built-in `web_search`, resolved server side
 - **Pattern**: Strategy pattern for tool implementations
+
+#### Browser Agent (`src/lib/browser-agent/`, `src/content/browser-agent.ts`)
+
+The browser tools (`browser_read_page`, `browser_list_elements`,
+`browser_click`, `browser_fill`, `browser_navigate`, `browser_scroll`) let the
+model operate the active tab. They run without user confirmation, and every call
+is logged into the chat by `ToolActivityLog`. The side panel sends commands
+through `browser-agent/bridge.ts`; the content script executes them against the
+real DOM. See [Browser Agent](./browser-agent.md).
 
 ### 4. Type System (`src/types/`)
 
@@ -79,6 +88,8 @@ User Input → InputArea → useApi → OpenAIClient → StreamProcessor → UI 
 
 ```
 OpenAI Tool Call → ToolExecutor → Chrome API → Tool Result → OpenAI → Response
+                                      │
+                                      └─ browser tools → content script → DOM
 ```
 
 ### State Management

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -5,6 +5,7 @@ import remarkGfm from "remark-gfm";
 import { Message } from "../types";
 import PersonIcon from "@mui/icons-material/Person";
 import SmartToyIcon from "@mui/icons-material/SmartToy";
+import ToolActivityLog from "./ToolActivityLog";
 
 interface ChatAreaProps {
   messages: Message[];
@@ -76,6 +77,11 @@ const ChatArea: React.FC<ChatAreaProps> = ({ messages, error }) => {
                 ))}
               </Box>
             )}
+            {/* Tool calls are logged inline so autonomous actions stay visible */}
+            {message.toolInteractions &&
+              message.toolInteractions.length > 0 && (
+                <ToolActivityLog interactions={message.toolInteractions} />
+              )}
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
               {message.content}
             </ReactMarkdown>

--- a/src/components/ToolActivityLog.tsx
+++ b/src/components/ToolActivityLog.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from "react";
+import { Box, Chip, Collapse, Typography } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import TerminalIcon from "@mui/icons-material/Terminal";
+import { ToolInteraction } from "../types";
+
+interface ToolActivityLogProps {
+  interactions: ToolInteraction[];
+}
+
+const MAX_RESULT_LENGTH = 800;
+
+/** Renders tool arguments as a compact one-liner, dropping empty values. */
+const formatArguments = (rawArguments: string): string => {
+  if (!rawArguments) return "";
+
+  try {
+    const parsed = JSON.parse(rawArguments);
+    if (typeof parsed !== "object" || parsed === null) return rawArguments;
+
+    const entries = Object.entries(parsed).filter(
+      ([, value]) => value !== null && value !== undefined && value !== "",
+    );
+    if (entries.length === 0) return "";
+
+    return entries
+      .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+      .join(", ");
+  } catch {
+    return rawArguments;
+  }
+};
+
+const truncate = (text: string): string =>
+  text.length > MAX_RESULT_LENGTH
+    ? `${text.slice(0, MAX_RESULT_LENGTH)}\n… (${text.length - MAX_RESULT_LENGTH} more characters)`
+    : text;
+
+/**
+ * Shows what the agent did on its own: browser tools run without asking for
+ * confirmation, so every call has to be readable afterwards in the chat log.
+ */
+const ToolActivityLog: React.FC<ToolActivityLogProps> = ({ interactions }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  if (interactions.length === 0) return null;
+
+  return (
+    <Box sx={{ mb: 1 }}>
+      <Chip
+        icon={<TerminalIcon />}
+        label={`${interactions.length} tool action${interactions.length > 1 ? "s" : ""}`}
+        size="small"
+        onClick={() => setExpanded((previous) => !previous)}
+        onDelete={() => setExpanded((previous) => !previous)}
+        deleteIcon={expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        sx={{ fontSize: "0.7rem" }}
+      />
+
+      <Collapse in={expanded}>
+        <Box
+          sx={{
+            mt: 1,
+            p: 1,
+            borderRadius: 1,
+            bgcolor: "grey.200",
+            fontFamily: "monospace",
+            fontSize: "0.7rem",
+            overflowX: "auto",
+          }}
+        >
+          {interactions.map((interaction, index) => {
+            const args = formatArguments(interaction.arguments);
+
+            return (
+              <Box
+                key={index}
+                sx={{ mb: index === interactions.length - 1 ? 0 : 1 }}
+              >
+                <Typography
+                  component="div"
+                  sx={{
+                    fontFamily: "inherit",
+                    fontSize: "inherit",
+                    fontWeight: 700,
+                  }}
+                >
+                  {interaction.name}
+                  {args ? `(${args})` : "()"}
+                </Typography>
+                <Typography
+                  component="pre"
+                  sx={{
+                    fontFamily: "inherit",
+                    fontSize: "inherit",
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                    m: 0,
+                    color: "text.secondary",
+                  }}
+                >
+                  {truncate(interaction.result)}
+                </Typography>
+              </Box>
+            );
+          })}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};
+
+export default ToolActivityLog;

--- a/src/components/__tests__/ChatArea.test.tsx
+++ b/src/components/__tests__/ChatArea.test.tsx
@@ -67,6 +67,23 @@ describe("ChatArea", () => {
     expect(screen.getByText("Typing...")).toBeInTheDocument();
   });
 
+  it("logs the tool actions attached to a message", () => {
+    const messageWithTools: Message = {
+      ...mockMessages[1],
+      toolInteractions: [
+        {
+          name: "browser_click",
+          arguments: '{"index":0,"selector":null}',
+          result: 'Clicked <button> "Log in".',
+        },
+      ],
+    };
+
+    render(<ChatArea messages={[messageWithTools]} />);
+
+    expect(screen.getByText("1 tool action")).toBeInTheDocument();
+  });
+
   it("displays error messages", () => {
     const errorMessage = "API connection error occurred";
     render(<ChatArea messages={[]} error={errorMessage} />);

--- a/src/components/__tests__/ToolActivityLog.test.tsx
+++ b/src/components/__tests__/ToolActivityLog.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import ToolActivityLog from "../ToolActivityLog";
+import { ToolInteraction } from "../../types";
+
+const interactions: ToolInteraction[] = [
+  {
+    name: "browser_list_elements",
+    arguments: '{"filter":"login","max_elements":null}',
+    result: '[0] <button> "Log in"',
+  },
+  {
+    name: "browser_click",
+    arguments: '{"index":0,"selector":null}',
+    result: 'Clicked <button> "Log in".',
+  },
+];
+
+describe("ToolActivityLog", () => {
+  it("renders nothing without interactions", () => {
+    const { container } = render(<ToolActivityLog interactions={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("summarises how many actions ran", () => {
+    render(<ToolActivityLog interactions={interactions} />);
+
+    expect(screen.getByText("2 tool actions")).toBeInTheDocument();
+  });
+
+  it("uses the singular form for a single action", () => {
+    render(<ToolActivityLog interactions={[interactions[0]]} />);
+
+    expect(screen.getByText("1 tool action")).toBeInTheDocument();
+  });
+
+  it("reveals the call arguments and results when expanded", async () => {
+    const user = userEvent.setup();
+    render(<ToolActivityLog interactions={interactions} />);
+
+    await user.click(screen.getByText("2 tool actions"));
+
+    expect(
+      screen.getByText('browser_list_elements(filter: "login")'),
+    ).toBeInTheDocument();
+    expect(screen.getByText("browser_click(index: 0)")).toBeInTheDocument();
+    expect(screen.getByText('Clicked <button> "Log in".')).toBeInTheDocument();
+  });
+
+  it("keeps unparseable arguments readable", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToolActivityLog
+        interactions={[{ name: "web_search", arguments: "oops", result: "ok" }]}
+      />,
+    );
+
+    await user.click(screen.getByText("1 tool action"));
+
+    expect(screen.getByText("web_search(oops)")).toBeInTheDocument();
+  });
+});

--- a/src/content/__tests__/browser-agent.test.ts
+++ b/src/content/__tests__/browser-agent.test.ts
@@ -1,0 +1,500 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  handleBrowserAgentCommand,
+  resetElementRegistry,
+} from "../browser-agent";
+
+const setBody = (html: string) => {
+  document.body.innerHTML = html;
+  resetElementRegistry();
+};
+
+/** Runs a command and fails loudly when it did not succeed. */
+const run = (command: Parameters<typeof handleBrowserAgentCommand>[0]) => {
+  const response = handleBrowserAgentCommand(command);
+  if (!response.ok) {
+    throw new Error(`Command failed: ${response.error}`);
+  }
+  return response.result;
+};
+
+/** Index of the element whose descriptor line contains the given text. */
+const indexOf = (listing: string, text: string): number => {
+  const line = listing
+    .split("\n")
+    .find((candidate) => candidate.includes(text));
+  if (!line) throw new Error(`No element line contains "${text}":\n${listing}`);
+  return Number(line.match(/^\[(\d+)\]/)![1]);
+};
+
+describe("browser agent commands", () => {
+  beforeEach(() => {
+    document.title = "Test Page";
+    setBody("");
+  });
+
+  describe("readPage", () => {
+    it("returns the page metadata and an indented outline", () => {
+      setBody(`
+        <div id="main">
+          <h1>Welcome</h1>
+          <p>Some body text</p>
+        </div>
+      `);
+
+      const result = run({ name: "readPage", selector: null, maxLength: null });
+
+      expect(result).toContain("Title: Test Page");
+      expect(result).toContain("URL: http://localhost:3000/");
+      expect(result).toContain('<div id="main">');
+      expect(result).toContain('<h1> "Welcome"');
+      expect(result).toContain('<p> "Some body text"');
+    });
+
+    it("keeps useful attributes on the outline lines", () => {
+      setBody(
+        '<a href="/about" class="nav-link" aria-label="About us">About</a>',
+      );
+
+      const result = run({ name: "readPage", selector: null, maxLength: null });
+
+      expect(result).toContain('href="/about"');
+      expect(result).toContain('aria-label="About us"');
+      expect(result).toContain('class="nav-link"');
+    });
+
+    it("skips script and style elements", () => {
+      setBody(
+        "<div><script>var secret = 1;</script><style>.a{color:red}</style><span>visible</span></div>",
+      );
+
+      const result = run({ name: "readPage", selector: null, maxLength: null });
+
+      expect(result).not.toContain("secret");
+      expect(result).not.toContain("color:red");
+      expect(result).toContain('<span> "visible"');
+    });
+
+    it("skips elements hidden with display none", () => {
+      setBody(
+        '<div><span style="display: none">hidden text</span><span>shown</span></div>',
+      );
+
+      const result = run({ name: "readPage", selector: null, maxLength: null });
+
+      expect(result).not.toContain("hidden text");
+      expect(result).toContain("shown");
+    });
+
+    it("limits the outline to the requested subtree", () => {
+      setBody(
+        '<div id="a"><p>inside a</p></div><div id="b"><p>inside b</p></div>',
+      );
+
+      const result = run({ name: "readPage", selector: "#b", maxLength: null });
+
+      expect(result).toContain("inside b");
+      expect(result).not.toContain("inside a");
+    });
+
+    it("truncates long outlines and says so", () => {
+      setBody(
+        Array.from(
+          { length: 50 },
+          (_, i) => `<p>paragraph number ${i}</p>`,
+        ).join(""),
+      );
+
+      const result = run({ name: "readPage", selector: null, maxLength: 120 });
+
+      expect(result).toContain("outline truncated");
+    });
+
+    it("reports an unmatched selector as an error", () => {
+      const response = handleBrowserAgentCommand({
+        name: "readPage",
+        selector: "#missing",
+        maxLength: null,
+      });
+
+      expect(response).toEqual({
+        ok: false,
+        error: "No element matches selector: #missing",
+      });
+    });
+  });
+
+  describe("listElements", () => {
+    it("indexes links, buttons and form controls", () => {
+      setBody(`
+        <a href="/home">Home</a>
+        <button id="save">Save</button>
+        <input name="q" type="text" placeholder="Search" />
+        <select name="size"><option value="s">Small</option></select>
+        <textarea name="note"></textarea>
+        <p>not interactive</p>
+      `);
+
+      const result = run({
+        name: "listElements",
+        filter: null,
+        maxElements: null,
+      });
+
+      expect(result).toContain("5 interactive element(s)");
+      expect(result).toContain('<a href="/home"> "Home"');
+      expect(result).toContain('<button id="save"> "Save"');
+      expect(result).toContain('placeholder="Search"');
+      expect(result).toContain("<textarea");
+      expect(result).not.toContain("not interactive");
+    });
+
+    it("exposes a usable selector for every element", () => {
+      setBody('<div><button id="save">Save</button></div>');
+
+      const result = run({
+        name: "listElements",
+        filter: null,
+        maxElements: null,
+      });
+
+      expect(result).toContain('selector="#save"');
+    });
+
+    it("builds a positional selector when there is no id", () => {
+      setBody("<div><button>One</button><button>Two</button></div>");
+
+      const result = run({
+        name: "listElements",
+        filter: null,
+        maxElements: null,
+      });
+
+      const selector = result
+        .split("\n")
+        .find((line) => line.includes('"Two"'))!
+        .match(/selector="([^"]+)"/)![1];
+
+      expect(document.querySelectorAll(selector)).toHaveLength(1);
+      expect(document.querySelector(selector)!.textContent).toBe("Two");
+    });
+
+    it("keeps only the elements matching the filter", () => {
+      setBody(`
+        <button>Save changes</button>
+        <button>Delete account</button>
+      `);
+
+      const result = run({
+        name: "listElements",
+        filter: "delete",
+        maxElements: null,
+      });
+
+      expect(result).toContain("Delete account");
+      expect(result).not.toContain("Save changes");
+    });
+
+    it("reports when nothing is interactive", () => {
+      setBody("<p>just text</p>");
+
+      const result = run({
+        name: "listElements",
+        filter: null,
+        maxElements: null,
+      });
+
+      expect(result).toBe("No interactive elements matched.");
+    });
+
+    it("caps the listing and mentions what was omitted", () => {
+      setBody(
+        Array.from(
+          { length: 5 },
+          (_, i) => `<button>Button ${i}</button>`,
+        ).join(""),
+      );
+
+      const result = run({
+        name: "listElements",
+        filter: null,
+        maxElements: 2,
+      });
+
+      expect(result).toContain("3 more element(s) omitted");
+    });
+  });
+
+  describe("click", () => {
+    it("clicks the element referenced by index", () => {
+      setBody('<button id="save">Save</button>');
+      const clicked = vi.fn();
+      document.getElementById("save")!.addEventListener("click", clicked);
+
+      const listing = run({
+        name: "listElements",
+        filter: null,
+        maxElements: null,
+      });
+      const result = run({
+        name: "click",
+        index: indexOf(listing, "Save"),
+        selector: null,
+      });
+
+      expect(clicked).toHaveBeenCalledTimes(1);
+      expect(result).toBe('Clicked <button> "Save".');
+    });
+
+    it("clicks the element referenced by selector", () => {
+      setBody('<button class="primary">Go</button>');
+      const clicked = vi.fn();
+      document.querySelector(".primary")!.addEventListener("click", clicked);
+
+      run({ name: "click", index: null, selector: ".primary" });
+
+      expect(clicked).toHaveBeenCalledTimes(1);
+    });
+
+    it("asks for a fresh listing when the index is unknown", () => {
+      setBody("<button>Save</button>");
+
+      const response = handleBrowserAgentCommand({
+        name: "click",
+        index: 42,
+        selector: null,
+      });
+
+      expect(response.ok).toBe(false);
+      expect(response.ok === false && response.error).toContain(
+        "No element at index 42",
+      );
+    });
+
+    it("reports elements that left the page", () => {
+      setBody('<button id="save">Save</button>');
+      run({ name: "listElements", filter: null, maxElements: null });
+      document.body.innerHTML = "";
+
+      const response = handleBrowserAgentCommand({
+        name: "click",
+        index: 0,
+        selector: null,
+      });
+
+      expect(response.ok).toBe(false);
+      expect(response.ok === false && response.error).toContain(
+        "no longer attached",
+      );
+    });
+
+    it("requires either an index or a selector", () => {
+      const response = handleBrowserAgentCommand({
+        name: "click",
+        index: null,
+        selector: null,
+      });
+
+      expect(response).toEqual({
+        ok: false,
+        error: "Either index or selector must be provided.",
+      });
+    });
+  });
+
+  describe("fill", () => {
+    it("fills a text input and fires input events", () => {
+      setBody('<input id="q" name="q" type="text" />');
+      const input = document.getElementById("q") as HTMLInputElement;
+      const onInput = vi.fn();
+      input.addEventListener("input", onInput);
+
+      const result = run({
+        name: "fill",
+        index: null,
+        selector: "#q",
+        value: "emerald",
+        submit: null,
+      });
+
+      expect(input.value).toBe("emerald");
+      expect(onInput).toHaveBeenCalledTimes(1);
+      expect(result).toContain('with "emerald"');
+    });
+
+    it("fills a textarea", () => {
+      setBody('<textarea id="note"></textarea>');
+
+      run({
+        name: "fill",
+        index: null,
+        selector: "#note",
+        value: "hello",
+        submit: null,
+      });
+
+      expect(
+        (document.getElementById("note") as HTMLTextAreaElement).value,
+      ).toBe("hello");
+    });
+
+    it("selects an option by its visible text", () => {
+      setBody(
+        '<select id="size"><option value="s">Small</option><option value="l">Large</option></select>',
+      );
+
+      const result = run({
+        name: "fill",
+        index: null,
+        selector: "#size",
+        value: "Large",
+        submit: null,
+      });
+
+      expect((document.getElementById("size") as HTMLSelectElement).value).toBe(
+        "l",
+      );
+      expect(result).toContain("Large");
+    });
+
+    it("lists the options when none matches", () => {
+      setBody('<select id="size"><option value="s">Small</option></select>');
+
+      const response = handleBrowserAgentCommand({
+        name: "fill",
+        index: null,
+        selector: "#size",
+        value: "Huge",
+        submit: null,
+      });
+
+      expect(response.ok).toBe(false);
+      expect(response.ok === false && response.error).toContain(
+        'Available: "Small"',
+      );
+    });
+
+    it("checks and unchecks a checkbox", () => {
+      setBody('<input id="agree" type="checkbox" />');
+      const checkbox = document.getElementById("agree") as HTMLInputElement;
+
+      run({
+        name: "fill",
+        index: null,
+        selector: "#agree",
+        value: "true",
+        submit: null,
+      });
+      expect(checkbox.checked).toBe(true);
+
+      run({
+        name: "fill",
+        index: null,
+        selector: "#agree",
+        value: "false",
+        submit: null,
+      });
+      expect(checkbox.checked).toBe(false);
+    });
+
+    it("fills a contenteditable element", () => {
+      setBody('<div id="editor" contenteditable="true"></div>');
+      const editor = document.getElementById("editor") as HTMLElement;
+      // jsdom does not derive isContentEditable from the attribute.
+      Object.defineProperty(editor, "isContentEditable", { value: true });
+
+      run({
+        name: "fill",
+        index: null,
+        selector: "#editor",
+        value: "typed text",
+        submit: null,
+      });
+
+      expect(editor.textContent).toBe("typed text");
+    });
+
+    it("submits the owning form when asked to", () => {
+      setBody('<form id="f"><input id="q" name="q" /></form>');
+      const form = document.getElementById("f") as HTMLFormElement;
+      const onSubmit = vi.fn((event: Event) => event.preventDefault());
+      form.addEventListener("submit", onSubmit);
+
+      const result = run({
+        name: "fill",
+        index: null,
+        selector: "#q",
+        value: "emerald",
+        submit: true,
+      });
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(result).toContain("Submitted the form.");
+    });
+
+    it("presses Enter when the control has no form", () => {
+      setBody('<input id="q" name="q" />');
+      const input = document.getElementById("q") as HTMLInputElement;
+      const onKeyDown = vi.fn();
+      input.addEventListener("keydown", onKeyDown);
+
+      const result = run({
+        name: "fill",
+        index: null,
+        selector: "#q",
+        value: "emerald",
+        submit: true,
+      });
+
+      expect(onKeyDown).toHaveBeenCalledTimes(1);
+      expect(result).toContain("Pressed Enter");
+    });
+
+    it("refuses elements that are not form controls", () => {
+      setBody("<button>Save</button>");
+
+      const response = handleBrowserAgentCommand({
+        name: "fill",
+        index: null,
+        selector: "button",
+        value: "x",
+        submit: null,
+      });
+
+      expect(response).toEqual({
+        ok: false,
+        error: "<button> is not a fillable form control.",
+      });
+    });
+  });
+
+  describe("scroll", () => {
+    it("scrolls the page to the bottom", () => {
+      const scrollTo = vi.fn();
+      window.scrollTo = scrollTo as unknown as typeof window.scrollTo;
+
+      const result = run({
+        name: "scroll",
+        direction: "bottom",
+        index: null,
+        selector: null,
+      });
+
+      expect(scrollTo).toHaveBeenCalled();
+      expect(result).toContain("bottom");
+    });
+
+    it("brings a single element into view", () => {
+      setBody('<button id="save">Save</button>');
+
+      const result = run({
+        name: "scroll",
+        direction: "element",
+        index: null,
+        selector: "#save",
+      });
+
+      expect(result).toBe('Scrolled <button> "Save" into view.');
+    });
+  });
+});

--- a/src/content/browser-agent.ts
+++ b/src/content/browser-agent.ts
@@ -1,0 +1,593 @@
+/**
+ * Page-side half of the browser agent.
+ *
+ * Everything here runs inside the content script, so it has direct access to
+ * the document of the tab the agent is driving. Commands arrive from the side
+ * panel and are answered with text that the model reads directly.
+ */
+import {
+  BrowserAgentCommand,
+  BrowserAgentResponse,
+  ScrollDirection,
+} from "../lib/browser-agent/types";
+
+/** Elements that carry no meaning for an agent reading the page. */
+const SKIPPED_TAGS = new Set([
+  "SCRIPT",
+  "STYLE",
+  "NOSCRIPT",
+  "TEMPLATE",
+  "LINK",
+  "META",
+  "HEAD",
+  "SVG",
+  "PATH",
+  "CANVAS",
+  "BR",
+]);
+
+/** Attributes worth showing in the outline, in the order they are printed. */
+const KEPT_ATTRIBUTES = [
+  "id",
+  "name",
+  "type",
+  "role",
+  "href",
+  "value",
+  "placeholder",
+  "aria-label",
+  "alt",
+  "title",
+  "for",
+  "data-testid",
+  "class",
+];
+
+const INTERACTIVE_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "label",
+  "[role='button']",
+  "[role='link']",
+  "[role='checkbox']",
+  "[role='radio']",
+  "[role='tab']",
+  "[role='menuitem']",
+  "[role='option']",
+  "[role='switch']",
+  "[role='combobox']",
+  "[contenteditable='true']",
+  "[onclick]",
+].join(",");
+
+const DEFAULT_OUTLINE_LENGTH = 12000;
+const DEFAULT_MAX_ELEMENTS = 150;
+const MAX_ATTRIBUTE_LENGTH = 80;
+const MAX_LABEL_LENGTH = 100;
+const MAX_SELECTOR_DEPTH = 6;
+
+/**
+ * Elements from the most recent `listElements` call, addressable by index.
+ * A fresh page load throws the whole content script away, so a stale index can
+ * only survive within a single document.
+ */
+let elementRegistry: Element[] = [];
+
+export function resetElementRegistry(): void {
+  elementRegistry = [];
+}
+
+/**
+ * Layout is only meaningful in a real browser: test environments report a zero
+ * rect for every node, so size is checked only when the document has layout.
+ */
+function hasLayout(): boolean {
+  const rect = document.body?.getBoundingClientRect();
+  return !!rect && (rect.width > 0 || rect.height > 0);
+}
+
+function isVisible(element: Element, layout: boolean): boolean {
+  if (!(element instanceof HTMLElement) && !(element instanceof SVGElement)) {
+    return false;
+  }
+  if (element.hasAttribute("hidden")) return false;
+  if (element.getAttribute("aria-hidden") === "true") return false;
+
+  const style = window.getComputedStyle(element);
+  if (style.display === "none" || style.visibility === "hidden") return false;
+  if (style.opacity === "0") return false;
+
+  if (layout) {
+    const rect = element.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return false;
+  }
+
+  return true;
+}
+
+function collapse(text: string, maxLength: number): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  return collapsed.length > maxLength
+    ? `${collapsed.slice(0, maxLength)}…`
+    : collapsed;
+}
+
+/** Short human-readable label, mirroring what a user would see on screen. */
+function labelOf(element: Element): string {
+  const ariaLabel = element.getAttribute("aria-label");
+  if (ariaLabel) return collapse(ariaLabel, MAX_LABEL_LENGTH);
+
+  if (element instanceof HTMLInputElement) {
+    if (element.type === "checkbox" || element.type === "radio") {
+      return collapse(element.value || element.name || "", MAX_LABEL_LENGTH);
+    }
+    return collapse(
+      element.placeholder || element.value || element.name || "",
+      MAX_LABEL_LENGTH,
+    );
+  }
+
+  if (element instanceof HTMLTextAreaElement) {
+    return collapse(
+      element.placeholder || element.name || "",
+      MAX_LABEL_LENGTH,
+    );
+  }
+
+  if (element instanceof HTMLSelectElement) {
+    const selected = element.selectedOptions[0];
+    return collapse(
+      selected ? selected.textContent || "" : element.name,
+      MAX_LABEL_LENGTH,
+    );
+  }
+
+  const text = element.textContent || "";
+  if (text.trim()) return collapse(text, MAX_LABEL_LENGTH);
+
+  return collapse(
+    element.getAttribute("title") || element.getAttribute("alt") || "",
+    MAX_LABEL_LENGTH,
+  );
+}
+
+function escapeIdent(value: string): string {
+  return typeof CSS !== "undefined" && typeof CSS.escape === "function"
+    ? CSS.escape(value)
+    : value.replace(/([^\w-])/g, "\\$1");
+}
+
+function isUniqueSelector(selector: string): boolean {
+  try {
+    return document.querySelectorAll(selector).length === 1;
+  } catch {
+    return false;
+  }
+}
+
+/** Best-effort CSS selector the agent can reuse after the page changes. */
+export function cssSelectorFor(element: Element): string {
+  const id = element.getAttribute("id");
+  if (id) {
+    const candidate = `#${escapeIdent(id)}`;
+    if (isUniqueSelector(candidate)) return candidate;
+  }
+
+  const testId = element.getAttribute("data-testid");
+  if (testId) {
+    const candidate = `[data-testid="${testId}"]`;
+    if (isUniqueSelector(candidate)) return candidate;
+  }
+
+  const parts: string[] = [];
+  let current: Element | null = element;
+  let depth = 0;
+
+  while (current && current !== document.documentElement) {
+    const tag = current.tagName.toLowerCase();
+    const parent: Element | null = current.parentElement;
+
+    if (!parent) {
+      parts.unshift(tag);
+      break;
+    }
+
+    const sameTag = Array.from(parent.children).filter(
+      (child) => child.tagName === current!.tagName,
+    );
+    parts.unshift(
+      sameTag.length > 1
+        ? `${tag}:nth-of-type(${sameTag.indexOf(current) + 1})`
+        : tag,
+    );
+
+    const candidate = parts.join(" > ");
+    if (isUniqueSelector(candidate)) return candidate;
+
+    const parentId = parent.getAttribute("id");
+    if (parentId) {
+      const scoped = `#${escapeIdent(parentId)} > ${candidate}`;
+      if (isUniqueSelector(scoped)) return scoped;
+    }
+
+    current = parent;
+    depth += 1;
+    if (depth >= MAX_SELECTOR_DEPTH) break;
+  }
+
+  return parts.join(" > ");
+}
+
+function attributeSummary(element: Element): string {
+  const parts: string[] = [];
+
+  for (const name of KEPT_ATTRIBUTES) {
+    const value = element.getAttribute(name);
+    if (value === null || value === "") continue;
+    parts.push(`${name}="${collapse(value, MAX_ATTRIBUTE_LENGTH)}"`);
+  }
+
+  if (element instanceof HTMLInputElement && element.checked) {
+    parts.push("checked");
+  }
+  if (
+    element instanceof HTMLElement &&
+    (element as HTMLInputElement).disabled === true
+  ) {
+    parts.push("disabled");
+  }
+
+  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+}
+
+/**
+ * Renders the document as an indented outline: one line per element, with its
+ * own text (not its descendants') appended. Far cheaper to read than raw HTML
+ * while keeping structure, attributes and text.
+ */
+export function outlinePage(
+  root: Element,
+  maxLength: number,
+): { text: string; truncated: boolean } {
+  const layout = hasLayout();
+  const lines: string[] = [];
+  let length = 0;
+  let truncated = false;
+
+  const walk = (element: Element, depth: number): void => {
+    if (truncated) return;
+    if (SKIPPED_TAGS.has(element.tagName)) return;
+    if (!isVisible(element, layout)) return;
+
+    const indent = "  ".repeat(depth);
+    const ownText = collapse(
+      Array.from(element.childNodes)
+        .filter((node) => node.nodeType === Node.TEXT_NODE)
+        .map((node) => node.textContent || "")
+        .join(" "),
+      MAX_LABEL_LENGTH * 3,
+    );
+
+    const line =
+      `${indent}<${element.tagName.toLowerCase()}${attributeSummary(element)}>` +
+      (ownText ? ` "${ownText}"` : "");
+
+    if (length + line.length > maxLength) {
+      truncated = true;
+      return;
+    }
+
+    lines.push(line);
+    length += line.length + 1;
+
+    for (const child of Array.from(element.children)) {
+      walk(child, depth + 1);
+    }
+  };
+
+  walk(root, 0);
+
+  return { text: lines.join("\n"), truncated };
+}
+
+/** Rebuilds the index registry and renders one line per interactive element. */
+export function listInteractiveElements(
+  filter: string | null,
+  maxElements: number,
+): string {
+  const layout = hasLayout();
+  const needle = filter ? filter.toLowerCase() : null;
+
+  elementRegistry = [];
+  const lines: string[] = [];
+  let skipped = 0;
+
+  for (const element of Array.from(
+    document.querySelectorAll(INTERACTIVE_SELECTOR),
+  )) {
+    if (!isVisible(element, layout)) continue;
+
+    const index = elementRegistry.length;
+    const label = labelOf(element);
+    const selector = cssSelectorFor(element);
+    const descriptor =
+      `[${index}] <${element.tagName.toLowerCase()}${attributeSummary(element)}>` +
+      (label ? ` "${label}"` : "") +
+      ` selector=${JSON.stringify(selector)}`;
+
+    if (needle && !descriptor.toLowerCase().includes(needle)) continue;
+
+    elementRegistry.push(element);
+
+    if (lines.length >= maxElements) {
+      skipped += 1;
+      continue;
+    }
+    lines.push(descriptor);
+  }
+
+  if (lines.length === 0) {
+    return "No interactive elements matched.";
+  }
+
+  const header = `${lines.length} interactive element(s) on ${document.title || "(untitled)"} — ${window.location.href}`;
+  const footer =
+    skipped > 0
+      ? `\n… ${skipped} more element(s) omitted; narrow the search with "filter".`
+      : "";
+
+  return `${header}\n${lines.join("\n")}${footer}`;
+}
+
+/** Resolves a command target, preferring the index from the last snapshot. */
+function resolveTarget(
+  index: number | null,
+  selector: string | null,
+): HTMLElement {
+  if (index !== null && index !== undefined) {
+    const element = elementRegistry[index];
+    if (!element) {
+      throw new Error(
+        `No element at index ${index}. Call browser_list_elements again to refresh the indices.`,
+      );
+    }
+    if (!element.isConnected) {
+      throw new Error(
+        `Element at index ${index} is no longer attached to the page. Call browser_list_elements again.`,
+      );
+    }
+    return element as HTMLElement;
+  }
+
+  if (selector) {
+    let element: Element | null;
+    try {
+      element = document.querySelector(selector);
+    } catch {
+      throw new Error(`Invalid CSS selector: ${selector}`);
+    }
+    if (!element) {
+      throw new Error(`No element matches selector: ${selector}`);
+    }
+    return element as HTMLElement;
+  }
+
+  throw new Error("Either index or selector must be provided.");
+}
+
+function describeTarget(element: Element): string {
+  const label = labelOf(element);
+  return `<${element.tagName.toLowerCase()}>` + (label ? ` "${label}"` : "");
+}
+
+function clickElement(element: HTMLElement): string {
+  element.scrollIntoView?.({ block: "center", inline: "nearest" });
+  element.focus?.();
+  element.click();
+  return `Clicked ${describeTarget(element)}.`;
+}
+
+/**
+ * Frameworks such as React track the value through the prototype setter, so
+ * assigning `element.value` directly would leave their state out of sync.
+ */
+function setNativeValue(element: HTMLElement, value: string): void {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(element),
+    "value",
+  );
+  if (descriptor?.set) {
+    descriptor.set.call(element, value);
+  } else {
+    (element as HTMLInputElement).value = value;
+  }
+}
+
+function dispatchInputEvents(element: HTMLElement): void {
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function fillSelect(element: HTMLSelectElement, value: string): string {
+  const options = Array.from(element.options);
+  const match =
+    options.find((option) => option.value === value) ??
+    options.find(
+      (option) =>
+        (option.textContent || "").trim().toLowerCase() ===
+        value.trim().toLowerCase(),
+    ) ??
+    options.find((option) =>
+      (option.textContent || "").toLowerCase().includes(value.toLowerCase()),
+    );
+
+  if (!match) {
+    const available = options
+      .map((option) => `"${(option.textContent || "").trim()}"`)
+      .join(", ");
+    throw new Error(`No option matches "${value}". Available: ${available}`);
+  }
+
+  element.value = match.value;
+  dispatchInputEvents(element);
+  return `Selected "${(match.textContent || match.value).trim()}".`;
+}
+
+function fillCheckable(element: HTMLInputElement, value: string): string {
+  const desired = !["false", "0", "no", "off", "unchecked", ""].includes(
+    value.trim().toLowerCase(),
+  );
+  if (element.checked !== desired) {
+    element.click();
+  }
+  return `${desired ? "Checked" : "Unchecked"} ${describeTarget(element)}.`;
+}
+
+function submitFrom(element: HTMLElement): string {
+  const form = (element as HTMLInputElement).form;
+  if (form) {
+    if (typeof form.requestSubmit === "function") {
+      form.requestSubmit();
+    } else {
+      form.submit();
+    }
+    return " Submitted the form.";
+  }
+
+  for (const type of ["keydown", "keypress", "keyup"] as const) {
+    element.dispatchEvent(
+      new KeyboardEvent(type, {
+        key: "Enter",
+        code: "Enter",
+        keyCode: 13,
+        bubbles: true,
+      }),
+    );
+  }
+  return " Pressed Enter (no owning form).";
+}
+
+function fillElement(
+  element: HTMLElement,
+  value: string,
+  submit: boolean,
+): string {
+  element.scrollIntoView?.({ block: "center", inline: "nearest" });
+  element.focus?.();
+
+  let message: string;
+
+  if (element instanceof HTMLSelectElement) {
+    message = fillSelect(element, value);
+  } else if (
+    element instanceof HTMLInputElement &&
+    (element.type === "checkbox" || element.type === "radio")
+  ) {
+    message = fillCheckable(element, value);
+  } else if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement
+  ) {
+    setNativeValue(element, value);
+    dispatchInputEvents(element);
+    message = `Filled ${describeTarget(element)} with "${collapse(value, MAX_LABEL_LENGTH)}".`;
+  } else if (element.isContentEditable) {
+    element.textContent = value;
+    dispatchInputEvents(element);
+    message = `Filled the contenteditable element with "${collapse(value, MAX_LABEL_LENGTH)}".`;
+  } else {
+    throw new Error(
+      `<${element.tagName.toLowerCase()}> is not a fillable form control.`,
+    );
+  }
+
+  return submit ? message + submitFrom(element) : message;
+}
+
+function scrollPage(
+  direction: ScrollDirection,
+  index: number | null,
+  selector: string | null,
+): string {
+  if (direction === "element") {
+    const element = resolveTarget(index, selector);
+    element.scrollIntoView?.({ block: "center", inline: "nearest" });
+    return `Scrolled ${describeTarget(element)} into view.`;
+  }
+
+  const viewport = window.innerHeight || 800;
+
+  switch (direction) {
+    case "top":
+      window.scrollTo(0, 0);
+      return "Scrolled to the top of the page.";
+    case "bottom":
+      window.scrollTo(0, document.body.scrollHeight);
+      return "Scrolled to the bottom of the page.";
+    case "up":
+      window.scrollBy(0, -viewport * 0.9);
+      return "Scrolled up one viewport.";
+    case "down":
+      window.scrollBy(0, viewport * 0.9);
+      return "Scrolled down one viewport.";
+  }
+}
+
+function runCommand(command: BrowserAgentCommand): string {
+  switch (command.name) {
+    case "readPage": {
+      const root = command.selector
+        ? document.querySelector(command.selector)
+        : document.body || document.documentElement;
+      if (!root) {
+        throw new Error(`No element matches selector: ${command.selector}`);
+      }
+
+      const { text, truncated } = outlinePage(
+        root,
+        command.maxLength ?? DEFAULT_OUTLINE_LENGTH,
+      );
+      const header = `Title: ${document.title}\nURL: ${window.location.href}\n\n`;
+      const footer = truncated
+        ? '\n\n… outline truncated. Narrow it with "selector" or raise "max_length".'
+        : "";
+      return header + text + footer;
+    }
+
+    case "listElements":
+      return listInteractiveElements(
+        command.filter,
+        command.maxElements ?? DEFAULT_MAX_ELEMENTS,
+      );
+
+    case "click":
+      return clickElement(resolveTarget(command.index, command.selector));
+
+    case "fill":
+      return fillElement(
+        resolveTarget(command.index, command.selector),
+        command.value,
+        command.submit ?? false,
+      );
+
+    case "scroll":
+      return scrollPage(command.direction, command.index, command.selector);
+  }
+}
+
+export function handleBrowserAgentCommand(
+  command: BrowserAgentCommand,
+): BrowserAgentResponse {
+  try {
+    return { ok: true, result: runCommand(command) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Browser command failed",
+    };
+  }
+}

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,9 +1,17 @@
 import { startRectangleSelection } from "./capture";
+import { handleBrowserAgentCommand } from "./browser-agent";
+import { BROWSER_AGENT_ACTION } from "../lib/browser-agent/types";
 
 chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
   console.log("Content script received message:", request);
 
   switch (request.action) {
+    case BROWSER_AGENT_ACTION:
+      // Answered synchronously: a command that navigates would otherwise tear
+      // the content script down before the response reaches the side panel.
+      sendResponse(handleBrowserAgentCommand(request.command));
+      break;
+
     case "getPageInfo":
       sendResponse({
         url: window.location.href,

--- a/src/hooks/__tests__/useChatThread.test.ts
+++ b/src/hooks/__tests__/useChatThread.test.ts
@@ -203,6 +203,67 @@ describe("useChatThread", () => {
     expect(result.current.messages[0].content).toBe("Hello! How can I help?");
   });
 
+  it("appends tool interactions to the streaming message", () => {
+    const { result } = renderHook(() => useChatThread());
+
+    act(() => {
+      result.current.addMessage(mockAIMessage);
+    });
+
+    act(() => {
+      result.current.appendToolInteractions([
+        {
+          name: "browser_read_page",
+          arguments: "{}",
+          result: "Title: Example",
+        },
+      ]);
+    });
+
+    act(() => {
+      result.current.appendToolInteractions([
+        { name: "browser_click", arguments: "{}", result: "Clicked." },
+      ]);
+    });
+
+    expect(result.current.messages[0].toolInteractions).toEqual([
+      { name: "browser_read_page", arguments: "{}", result: "Title: Example" },
+      { name: "browser_click", arguments: "{}", result: "Clicked." },
+    ]);
+  });
+
+  it("appendToolInteractions does nothing when there is nothing to log", () => {
+    const { result } = renderHook(() => useChatThread());
+
+    act(() => {
+      result.current.addMessage(mockAIMessage);
+      result.current.appendToolInteractions([]);
+    });
+
+    expect(result.current.messages[0].toolInteractions).toBeUndefined();
+  });
+
+  it("keeps the tool log when the message completes", async () => {
+    const { result } = renderHook(() => useChatThread());
+
+    act(() => {
+      result.current.addMessage(mockAIMessage);
+    });
+
+    act(() => {
+      result.current.appendToolInteractions([
+        { name: "browser_click", arguments: "{}", result: "Clicked." },
+      ]);
+    });
+
+    await act(async () => {
+      result.current.completeLastMessage();
+    });
+
+    expect(result.current.messages[0].status).toBe("done");
+    expect(result.current.messages[0].toolInteractions).toHaveLength(1);
+  });
+
   it("restores the conversation tied to the current group on mount", async () => {
     setActiveTabGroup(42);
     vi.mocked(groupChatStorage.getGroupChat).mockResolvedValueOnce([

--- a/src/hooks/useChatThread.ts
+++ b/src/hooks/useChatThread.ts
@@ -68,6 +68,27 @@ export const useChatThread = () => {
     });
   };
 
+  // Tools run while the answer is still streaming, so their log lands in the
+  // chat as it happens rather than only once the message is finished.
+  const appendToolInteractions = (interactions: ToolInteraction[]) => {
+    if (interactions.length === 0) return;
+
+    setMessages((prev) => {
+      if (prev.length === 0) return prev;
+
+      const newMessages = [...prev];
+      const lastMessage = newMessages[newMessages.length - 1];
+      newMessages[newMessages.length - 1] = {
+        ...lastMessage,
+        toolInteractions: [
+          ...(lastMessage.toolInteractions ?? []),
+          ...interactions,
+        ],
+      };
+      return newMessages;
+    });
+  };
+
   const completeLastMessage = (toolInteractions?: ToolInteraction[]) => {
     setMessages((prev) => {
       const newMessages = [...prev];
@@ -101,6 +122,7 @@ export const useChatThread = () => {
     messages,
     addMessage,
     appendToLastMessage,
+    appendToolInteractions,
     completeLastMessage,
     clearCurrentGroupChat,
   };

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -28,7 +28,7 @@ interface Settings {
 const DEFAULT_SETTINGS: Settings = {
   openaiApiKey: "",
   systemPrompt:
-    "You are a helpful AI assistant integrated into a Chrome extension called Emerald. You can help users with various tasks while they browse the web. When users provide page content, use it to give more contextual and relevant responses. Use the built-in web search tool whenever up-to-date or external information would help, and cite the source URLs as Markdown links. Be concise but helpful, and adapt your responses to the context of what the user is doing.",
+    "You are a helpful AI assistant integrated into a Chrome extension called Emerald. You can help users with various tasks while they browse the web. When users provide page content, use it to give more contextual and relevant responses. Use the built-in web search tool whenever up-to-date or external information would help, and cite the source URLs as Markdown links. You can also drive the active tab yourself with the browser tools: read the page with browser_read_page, discover what you can act on with browser_list_elements, then use browser_click, browser_fill, browser_scroll and browser_navigate. Always list the elements again after the page changes, because the indices are only valid for the page you listed them on. Be concise but helpful, and adapt your responses to the context of what the user is doing.",
   model: DEFAULT_MODEL,
   reasoningEffort: DEFAULT_REASONING_EFFORT,
   modelSelectorOpen: false,

--- a/src/lib/browser-agent/bridge.ts
+++ b/src/lib/browser-agent/bridge.ts
@@ -1,0 +1,142 @@
+/**
+ * Side-panel half of the browser agent: locates the tab under control and
+ * relays commands to the content script running inside it.
+ */
+import {
+  BROWSER_AGENT_ACTION,
+  BrowserAgentCommand,
+  BrowserAgentResponse,
+} from "./types";
+
+const LOAD_POLL_INTERVAL_MS = 150;
+const LOAD_TIMEOUT_MS = 15000;
+/** Time given to a click before the resulting navigation is looked at. */
+const NAVIGATION_SETTLE_MS = 400;
+
+export interface TabState {
+  id: number;
+  url: string;
+  title: string;
+}
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function getActiveTab(): Promise<TabState> {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+  if (!tab?.id) {
+    throw new Error("No active tab found.");
+  }
+
+  return { id: tab.id, url: tab.url ?? "", title: tab.title ?? "" };
+}
+
+/** Resolves once the tab finished loading, or when the timeout elapses. */
+export async function waitForTabLoad(tabId: number): Promise<TabState> {
+  const deadline = Date.now() + LOAD_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const tab = await chrome.tabs.get(tabId);
+    if (tab.status === "complete") {
+      return { id: tabId, url: tab.url ?? "", title: tab.title ?? "" };
+    }
+    await delay(LOAD_POLL_INTERVAL_MS);
+  }
+
+  const tab = await chrome.tabs.get(tabId);
+  return { id: tabId, url: tab.url ?? "", title: tab.title ?? "" };
+}
+
+/**
+ * A click can tear the page down before the content script answers. That is a
+ * successful navigation rather than a failure, so the disconnect is reported
+ * as such instead of surfacing a raw messaging error.
+ */
+function isDisconnectError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Receiving end does not exist") ||
+    message.includes("message port closed") ||
+    message.includes("message channel closed")
+  );
+}
+
+export class ContentScriptUnavailableError extends Error {
+  constructor() {
+    super(
+      "The page cannot be driven: no content script is running in the active tab. " +
+        "Browser-internal pages (chrome://, about:, the extension gallery) are off limits; " +
+        "for a normal page, reload it and try again.",
+    );
+    this.name = "ContentScriptUnavailableError";
+  }
+}
+
+/** Sends one command and unwraps the content script's answer. */
+export async function sendBrowserCommand(
+  tabId: number,
+  command: BrowserAgentCommand,
+): Promise<string> {
+  let response: BrowserAgentResponse | undefined;
+
+  try {
+    response = (await chrome.tabs.sendMessage(tabId, {
+      action: BROWSER_AGENT_ACTION,
+      command,
+    })) as BrowserAgentResponse | undefined;
+  } catch (error) {
+    if (isDisconnectError(error)) {
+      throw new ContentScriptUnavailableError();
+    }
+    throw error;
+  }
+
+  if (!response) {
+    throw new ContentScriptUnavailableError();
+  }
+
+  if (!response.ok) {
+    throw new Error(response.error);
+  }
+
+  return response.result;
+}
+
+/**
+ * Runs a command that may navigate away. The content script is told to answer
+ * before the navigation starts; if it disappears first, the tab state is read
+ * back from the tabs API instead.
+ */
+export async function sendNavigatingCommand(
+  tabId: number,
+  command: BrowserAgentCommand,
+): Promise<string> {
+  const before = await getActiveTab();
+  let result: string;
+
+  try {
+    result = await sendBrowserCommand(tabId, command);
+  } catch (error) {
+    if (!(error instanceof ContentScriptUnavailableError)) throw error;
+    result = "Command triggered an immediate navigation.";
+  }
+
+  await delay(NAVIGATION_SETTLE_MS);
+  const after = await waitForTabLoad(tabId);
+
+  if (after.url !== before.url) {
+    return `${result}\nNavigated to ${after.url} (${after.title}).`;
+  }
+
+  return `${result}\nStill on ${after.url}.`;
+}
+
+export async function navigateTab(
+  tabId: number,
+  url: string,
+): Promise<TabState> {
+  await chrome.tabs.update(tabId, { url });
+  await delay(NAVIGATION_SETTLE_MS);
+  return waitForTabLoad(tabId);
+}

--- a/src/lib/browser-agent/types.ts
+++ b/src/lib/browser-agent/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Contract between the side panel (where the agent runs) and the content
+ * script (which owns the DOM of the page being driven).
+ */
+
+/** Message action used for every browser agent command. */
+export const BROWSER_AGENT_ACTION = "browserAgent";
+
+export type ScrollDirection = "top" | "bottom" | "up" | "down" | "element";
+
+export interface ReadPageCommand {
+  name: "readPage";
+  /** Limit the outline to a subtree. Whole document when null. */
+  selector: string | null;
+  /** Maximum number of characters in the outline. */
+  maxLength: number | null;
+}
+
+export interface ListElementsCommand {
+  name: "listElements";
+  /** Case-insensitive substring the element label or selector must contain. */
+  filter: string | null;
+  maxElements: number | null;
+}
+
+export interface ClickCommand {
+  name: "click";
+  /** Index from the most recent listElements snapshot. */
+  index: number | null;
+  /** CSS selector, used when no index is given. */
+  selector: string | null;
+}
+
+export interface FillCommand {
+  name: "fill";
+  index: number | null;
+  selector: string | null;
+  value: string;
+  /** Submit the owning form (or press Enter) after filling. */
+  submit: boolean | null;
+}
+
+export interface ScrollCommand {
+  name: "scroll";
+  direction: ScrollDirection;
+  index: number | null;
+  selector: string | null;
+}
+
+export type BrowserAgentCommand =
+  | ReadPageCommand
+  | ListElementsCommand
+  | ClickCommand
+  | FillCommand
+  | ScrollCommand;
+
+export interface BrowserAgentRequest {
+  action: typeof BROWSER_AGENT_ACTION;
+  command: BrowserAgentCommand;
+}
+
+/**
+ * Commands answer with plain text: the content script already formats the DOM
+ * into the shape the model reads, so nothing has to be re-serialized later.
+ */
+export type BrowserAgentResponse =
+  { ok: true; result: string } | { ok: false; error: string };

--- a/src/lib/openai/__tests__/client.test.ts
+++ b/src/lib/openai/__tests__/client.test.ts
@@ -146,7 +146,7 @@ describe("OpenAIClient", () => {
       expect(followUpBody.reasoning).toEqual({ effort: "high" });
     });
 
-    it("should offer the local function tool and the built-in web search", async () => {
+    it("should offer the local function tools and the built-in web search", async () => {
       globalThis.fetch = vi
         .fn()
         .mockResolvedValue(createMockResponse([textDelta("test")]));
@@ -157,10 +157,13 @@ describe("OpenAIClient", () => {
         (globalThis.fetch as any).mock.calls[0][1].body,
       );
 
-      expect(requestBody.tools).toEqual([
+      expect(requestBody.tools).toContainEqual(
         expect.objectContaining({ type: "function", name: "get_current_time" }),
-        { type: "web_search" },
-      ]);
+      );
+      expect(requestBody.tools).toContainEqual(
+        expect.objectContaining({ type: "function", name: "browser_click" }),
+      );
+      expect(requestBody.tools).toContainEqual({ type: "web_search" });
     });
 
     it("should handle HTTP errors", async () => {

--- a/src/lib/tools/__tests__/browser-tools.test.ts
+++ b/src/lib/tools/__tests__/browser-tools.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  BROWSER_TOOLS,
+  executeBrowserTool,
+  isBrowserToolName,
+} from "../browser-tools";
+import { BROWSER_AGENT_ACTION } from "../../browser-agent/types";
+
+const activeTab = {
+  id: 7,
+  url: "https://example.com",
+  title: "Example",
+  status: "complete",
+};
+
+const sendMessage = () =>
+  chrome.tabs.sendMessage as unknown as ReturnType<typeof vi.fn>;
+
+/** Last command object handed to the content script. */
+const lastCommand = () => sendMessage().mock.calls.at(-1)![1].command;
+
+describe("browser tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (chrome.tabs.query as any).mockResolvedValue([activeTab]);
+    (chrome.tabs.get as any).mockResolvedValue(activeTab);
+    (chrome.tabs.update as any).mockResolvedValue(activeTab);
+    sendMessage().mockResolvedValue({ ok: true, result: "done" });
+  });
+
+  describe("definitions", () => {
+    it("declares every browser tool in strict Responses API format", () => {
+      expect(BROWSER_TOOLS.map((tool) => tool.name)).toEqual([
+        "browser_read_page",
+        "browser_list_elements",
+        "browser_click",
+        "browser_fill",
+        "browser_navigate",
+        "browser_scroll",
+      ]);
+
+      for (const tool of BROWSER_TOOLS) {
+        expect(tool.type).toBe("function");
+        expect(tool.strict).toBe(true);
+        expect(tool.parameters.additionalProperties).toBe(false);
+        // Strict mode requires every declared property to be required.
+        expect(tool.parameters.required.sort()).toEqual(
+          Object.keys(tool.parameters.properties).sort(),
+        );
+      }
+    });
+
+    it("recognises its own tool names only", () => {
+      expect(isBrowserToolName("browser_click")).toBe(true);
+      expect(isBrowserToolName("get_current_time")).toBe(false);
+    });
+  });
+
+  describe("execution", () => {
+    it("sends a readPage command to the active tab", async () => {
+      const result = await executeBrowserTool("browser_read_page", {
+        selector: "#main",
+        max_length: 500,
+      });
+
+      expect(sendMessage()).toHaveBeenCalledWith(7, {
+        action: BROWSER_AGENT_ACTION,
+        command: { name: "readPage", selector: "#main", maxLength: 500 },
+      });
+      expect(result).toBe("done");
+    });
+
+    it("passes nulls through for omitted optional arguments", async () => {
+      await executeBrowserTool("browser_list_elements", {
+        filter: null,
+        max_elements: null,
+      });
+
+      expect(lastCommand()).toEqual({
+        name: "listElements",
+        filter: null,
+        maxElements: null,
+      });
+    });
+
+    it("accepts an index that arrives as a string", async () => {
+      await executeBrowserTool("browser_click", { index: "3", selector: null });
+
+      expect(lastCommand()).toEqual({
+        name: "click",
+        index: 3,
+        selector: null,
+      });
+    });
+
+    it("reports where a click left the page", async () => {
+      (chrome.tabs.get as any).mockResolvedValue({
+        ...activeTab,
+        url: "https://example.com/next",
+        title: "Next",
+      });
+      sendMessage().mockResolvedValue({ ok: true, result: "Clicked <a>." });
+
+      const result = await executeBrowserTool("browser_click", {
+        index: 0,
+        selector: null,
+      });
+
+      expect(result).toContain("Clicked <a>.");
+      expect(result).toContain("Navigated to https://example.com/next (Next).");
+    });
+
+    it("treats a lost content script after a click as a navigation", async () => {
+      sendMessage().mockRejectedValue(
+        new Error(
+          "Could not establish connection. Receiving end does not exist.",
+        ),
+      );
+      (chrome.tabs.get as any).mockResolvedValue({
+        ...activeTab,
+        url: "https://example.com/next",
+        title: "Next",
+      });
+
+      const result = await executeBrowserTool("browser_click", {
+        index: 0,
+        selector: null,
+      });
+
+      expect(result).toContain("Navigated to https://example.com/next");
+    });
+
+    it("does not wait for a navigation on a plain fill", async () => {
+      await executeBrowserTool("browser_fill", {
+        index: 2,
+        selector: null,
+        value: "emerald",
+        submit: null,
+      });
+
+      expect(lastCommand()).toEqual({
+        name: "fill",
+        index: 2,
+        selector: null,
+        value: "emerald",
+        submit: null,
+      });
+      expect(chrome.tabs.get).not.toHaveBeenCalled();
+    });
+
+    it("waits for the page after a submitting fill", async () => {
+      await executeBrowserTool("browser_fill", {
+        index: 2,
+        selector: null,
+        value: "emerald",
+        submit: true,
+      });
+
+      expect(chrome.tabs.get).toHaveBeenCalledWith(7);
+    });
+
+    it("opens a URL and waits for the load to finish", async () => {
+      (chrome.tabs.get as any).mockResolvedValue({
+        ...activeTab,
+        url: "https://example.org/",
+        title: "Other",
+      });
+
+      const result = await executeBrowserTool("browser_navigate", {
+        url: "https://example.org/",
+      });
+
+      expect(chrome.tabs.update).toHaveBeenCalledWith(7, {
+        url: "https://example.org/",
+      });
+      expect(result).toBe("Opened https://example.org/ (Other).");
+    });
+
+    it("rejects an unknown scroll direction", async () => {
+      await expect(
+        executeBrowserTool("browser_scroll", {
+          direction: "sideways",
+          index: null,
+          selector: null,
+        }),
+      ).rejects.toThrow('"direction" must be one of');
+    });
+
+    it("surfaces the error reported by the content script", async () => {
+      sendMessage().mockResolvedValue({
+        ok: false,
+        error: "No element at index 9",
+      });
+
+      await expect(
+        executeBrowserTool("browser_read_page", {
+          selector: null,
+          max_length: null,
+        }),
+      ).rejects.toThrow("No element at index 9");
+    });
+
+    it("explains a missing content script", async () => {
+      sendMessage().mockResolvedValue(undefined);
+
+      await expect(
+        executeBrowserTool("browser_read_page", {
+          selector: null,
+          max_length: null,
+        }),
+      ).rejects.toThrow("no content script is running in the active tab");
+    });
+
+    it("fails when there is no active tab", async () => {
+      (chrome.tabs.query as any).mockResolvedValue([]);
+
+      await expect(
+        executeBrowserTool("browser_read_page", {
+          selector: null,
+          max_length: null,
+        }),
+      ).rejects.toThrow("No active tab found.");
+    });
+  });
+});

--- a/src/lib/tools/__tests__/executor.test.ts
+++ b/src/lib/tools/__tests__/executor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ToolExecutor, getAvailableTools } from "../executor";
-import { FunctionCallItem } from "../../../types/openai";
+import { FunctionCallItem, FunctionTool } from "../../../types/openai";
 
 const functionCall = (
   callId: string,
@@ -72,19 +72,78 @@ describe("ToolExecutor", () => {
     });
   });
 
+  describe("browser tools", () => {
+    it("routes a browser tool to the active tab and returns its output", async () => {
+      (chrome.tabs.query as any).mockResolvedValue([
+        { id: 3, url: "https://example.com", title: "Example" },
+      ]);
+      (chrome.tabs.sendMessage as any).mockResolvedValue({
+        ok: true,
+        result: "Title: Example",
+      });
+
+      const results = await toolExecutor.execute([
+        functionCall(
+          "test-id-1",
+          "browser_read_page",
+          '{"selector":null,"max_length":null}',
+        ),
+      ]);
+
+      expect(results).toEqual([
+        {
+          type: "function_call_output",
+          call_id: "test-id-1",
+          output: "Title: Example",
+        },
+      ]);
+    });
+
+    it("feeds a browser tool failure back to the model", async () => {
+      (chrome.tabs.query as any).mockResolvedValue([
+        { id: 3, url: "https://example.com", title: "Example" },
+      ]);
+      (chrome.tabs.sendMessage as any).mockResolvedValue({
+        ok: false,
+        error: "No element at index 9",
+      });
+
+      const results = await toolExecutor.execute([
+        functionCall(
+          "test-id-1",
+          "browser_click",
+          '{"index":9,"selector":null}',
+        ),
+      ]);
+
+      expect(results[0].output).toBe("Error: No element at index 9");
+    });
+
+    it("reports malformed tool arguments instead of crashing", async () => {
+      const results = await toolExecutor.execute([
+        functionCall("test-id-1", "browser_read_page", "{not json"),
+      ]);
+
+      expect(results[0].output).toContain("Invalid JSON arguments");
+    });
+  });
+
   describe("getAvailableTools", () => {
     it("exposes the local function tools in the Responses API format", () => {
       const functionTools = getAvailableTools().filter(
-        (tool) => tool.type === "function",
+        (tool): tool is FunctionTool => tool.type === "function",
       );
 
-      expect(functionTools).toEqual([
-        expect.objectContaining({
-          type: "function",
-          name: "get_current_time",
-          strict: true,
-        }),
+      expect(functionTools.map((tool) => tool.name)).toEqual([
+        "get_current_time",
+        "browser_read_page",
+        "browser_list_elements",
+        "browser_click",
+        "browser_fill",
+        "browser_navigate",
+        "browser_scroll",
       ]);
+      expect(functionTools.every((tool) => tool.strict)).toBe(true);
     });
 
     it("enables the built-in web search tool", () => {

--- a/src/lib/tools/browser-tools.ts
+++ b/src/lib/tools/browser-tools.ts
@@ -1,0 +1,292 @@
+/**
+ * Function tools that let the model drive the tab the side panel is attached
+ * to. They run without asking the user for confirmation; every call is echoed
+ * into the chat log so the operation stays visible.
+ */
+import { FunctionTool } from "../../types/openai";
+import { ScrollDirection } from "../browser-agent/types";
+import {
+  getActiveTab,
+  navigateTab,
+  sendBrowserCommand,
+  sendNavigatingCommand,
+} from "../browser-agent/bridge";
+
+const SCROLL_DIRECTIONS: ScrollDirection[] = [
+  "top",
+  "bottom",
+  "up",
+  "down",
+  "element",
+];
+
+export const BROWSER_TOOLS: FunctionTool[] = [
+  {
+    type: "function",
+    name: "browser_read_page",
+    description:
+      "Read the DOM of the page currently open in the active tab. Returns the title, the URL and an indented outline of the visible elements: one line per element with its tag, its useful attributes (id, name, type, href, aria-label, class, …) and its own text. Use this to understand what is on the page before acting on it.",
+    parameters: {
+      type: "object",
+      properties: {
+        selector: {
+          type: ["string", "null"],
+          description:
+            "CSS selector to limit the outline to one subtree. Null reads the whole document body.",
+        },
+        max_length: {
+          type: ["integer", "null"],
+          description:
+            "Maximum number of characters of outline to return. Null uses the default of 12000.",
+        },
+      },
+      required: ["selector", "max_length"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+  {
+    type: "function",
+    name: "browser_list_elements",
+    description:
+      "List the interactive elements of the active tab: links, buttons, inputs, textareas, selects and ARIA widgets. Each line carries an index, the tag, its attributes, a label and a CSS selector. The indices stay valid until the page changes, and browser_click / browser_fill / browser_scroll accept them. Call this before clicking or filling anything.",
+    parameters: {
+      type: "object",
+      properties: {
+        filter: {
+          type: ["string", "null"],
+          description:
+            'Case-insensitive substring an element line must contain, e.g. "login". Null lists everything.',
+        },
+        max_elements: {
+          type: ["integer", "null"],
+          description:
+            "Maximum number of elements to return. Null uses the default of 150.",
+        },
+      },
+      required: ["filter", "max_elements"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+  {
+    type: "function",
+    name: "browser_click",
+    description:
+      "Click an element in the active tab, identified either by its index from browser_list_elements or by a CSS selector. The element is scrolled into view first. Reports where the page ended up, so a click that navigates is easy to follow.",
+    parameters: {
+      type: "object",
+      properties: {
+        index: {
+          type: ["integer", "null"],
+          description:
+            "Index from the most recent browser_list_elements call. Preferred over selector.",
+        },
+        selector: {
+          type: ["string", "null"],
+          description: "CSS selector of the element, used when index is null.",
+        },
+      },
+      required: ["index", "selector"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+  {
+    type: "function",
+    name: "browser_fill",
+    description:
+      'Fill a form control in the active tab. Works on text inputs, textareas and contenteditable elements (the value is typed in), on selects (the value matches an option by value or by visible text) and on checkboxes and radios ("true" checks, "false" unchecks). Set submit to true to submit the owning form afterwards.',
+    parameters: {
+      type: "object",
+      properties: {
+        index: {
+          type: ["integer", "null"],
+          description:
+            "Index from the most recent browser_list_elements call. Preferred over selector.",
+        },
+        selector: {
+          type: ["string", "null"],
+          description:
+            "CSS selector of the form control, used when index is null.",
+        },
+        value: {
+          type: "string",
+          description: "Value to put into the control.",
+        },
+        submit: {
+          type: ["boolean", "null"],
+          description:
+            "Submit the owning form after filling (falls back to pressing Enter). Null means no submit.",
+        },
+      },
+      required: ["index", "selector", "value", "submit"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+  {
+    type: "function",
+    name: "browser_navigate",
+    description:
+      "Open a URL in the active tab and wait for it to finish loading. Use this to start a task on a known page, then read it with browser_read_page.",
+    parameters: {
+      type: "object",
+      properties: {
+        url: {
+          type: "string",
+          description: "Absolute URL to open, including the scheme.",
+        },
+      },
+      required: ["url"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+  {
+    type: "function",
+    name: "browser_scroll",
+    description:
+      'Scroll the active tab. Use "down" or "up" to move by one viewport (which also triggers lazy loading), "top" or "bottom" to jump, or "element" together with an index or selector to bring one element into view.',
+    parameters: {
+      type: "object",
+      properties: {
+        direction: {
+          type: "string",
+          enum: SCROLL_DIRECTIONS,
+          description: "Where to scroll.",
+        },
+        index: {
+          type: ["integer", "null"],
+          description: 'Element index, required when direction is "element".',
+        },
+        selector: {
+          type: ["string", "null"],
+          description:
+            'CSS selector, an alternative to index when direction is "element".',
+        },
+      },
+      required: ["direction", "index", "selector"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+];
+
+const BROWSER_TOOL_NAMES = new Set(BROWSER_TOOLS.map((tool) => tool.name));
+
+export function isBrowserToolName(name: string): boolean {
+  return BROWSER_TOOL_NAMES.has(name);
+}
+
+type Arguments = Record<string, unknown>;
+
+function optionalString(args: Arguments, key: string): string | null {
+  const value = args[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function requiredString(args: Arguments, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string") {
+    throw new Error(`Missing required "${key}" argument.`);
+  }
+  return value;
+}
+
+function optionalNumber(args: Arguments, key: string): number | null {
+  const value = args[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  // Models occasionally send an index as a string; accept it rather than fail.
+  if (
+    typeof value === "string" &&
+    value.trim() !== "" &&
+    !isNaN(Number(value))
+  ) {
+    return Number(value);
+  }
+  return null;
+}
+
+function optionalBoolean(args: Arguments, key: string): boolean | null {
+  const value = args[key];
+  if (typeof value === "boolean") return value;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
+function scrollDirection(args: Arguments): ScrollDirection {
+  const value = args.direction;
+  if (
+    typeof value === "string" &&
+    (SCROLL_DIRECTIONS as string[]).includes(value)
+  ) {
+    return value as ScrollDirection;
+  }
+  throw new Error(
+    `"direction" must be one of: ${SCROLL_DIRECTIONS.join(", ")}.`,
+  );
+}
+
+export async function executeBrowserTool(
+  name: string,
+  args: Arguments,
+): Promise<string> {
+  const tab = await getActiveTab();
+
+  switch (name) {
+    case "browser_read_page":
+      return sendBrowserCommand(tab.id, {
+        name: "readPage",
+        selector: optionalString(args, "selector"),
+        maxLength: optionalNumber(args, "max_length"),
+      });
+
+    case "browser_list_elements":
+      return sendBrowserCommand(tab.id, {
+        name: "listElements",
+        filter: optionalString(args, "filter"),
+        maxElements: optionalNumber(args, "max_elements"),
+      });
+
+    case "browser_click":
+      return sendNavigatingCommand(tab.id, {
+        name: "click",
+        index: optionalNumber(args, "index"),
+        selector: optionalString(args, "selector"),
+      });
+
+    case "browser_fill": {
+      const submit = optionalBoolean(args, "submit");
+      const command = {
+        name: "fill" as const,
+        index: optionalNumber(args, "index"),
+        selector: optionalString(args, "selector"),
+        value: requiredString(args, "value"),
+        submit,
+      };
+      // Only a submit can navigate away; a plain fill answers immediately.
+      return submit
+        ? sendNavigatingCommand(tab.id, command)
+        : sendBrowserCommand(tab.id, command);
+    }
+
+    case "browser_navigate": {
+      const url = requiredString(args, "url");
+      const state = await navigateTab(tab.id, url);
+      return `Opened ${state.url} (${state.title}).`;
+    }
+
+    case "browser_scroll":
+      return sendBrowserCommand(tab.id, {
+        name: "scroll",
+        direction: scrollDirection(args),
+        index: optionalNumber(args, "index"),
+        selector: optionalString(args, "selector"),
+      });
+
+    default:
+      throw new Error(`Unknown browser tool: ${name}`);
+  }
+}

--- a/src/lib/tools/executor.ts
+++ b/src/lib/tools/executor.ts
@@ -6,6 +6,11 @@ import {
   ToolExecutionError,
   WebSearchTool,
 } from "../../types/openai";
+import {
+  BROWSER_TOOLS,
+  executeBrowserTool,
+  isBrowserToolName,
+} from "./browser-tools";
 
 export const AVAILABLE_TOOLS: FunctionTool[] = [
   {
@@ -21,6 +26,7 @@ export const AVAILABLE_TOOLS: FunctionTool[] = [
     },
     strict: true,
   },
+  ...BROWSER_TOOLS,
 ];
 
 /**
@@ -60,6 +66,17 @@ export class ToolExecutor {
   private async executeSingleTool(
     functionCall: FunctionCallItem,
   ): Promise<FunctionCallOutputItem> {
+    if (isBrowserToolName(functionCall.name)) {
+      return {
+        type: "function_call_output",
+        call_id: functionCall.call_id,
+        output: await executeBrowserTool(
+          functionCall.name,
+          this.parseArguments(functionCall),
+        ),
+      };
+    }
+
     switch (functionCall.name) {
       case "get_current_time":
         return this.executeGetCurrentTime(functionCall.call_id);
@@ -68,6 +85,23 @@ export class ToolExecutor {
           `Unknown tool: ${functionCall.name}`,
           functionCall.name,
         );
+    }
+  }
+
+  private parseArguments(
+    functionCall: FunctionCallItem,
+  ): Record<string, unknown> {
+    if (!functionCall.arguments) return {};
+
+    try {
+      const parsed = JSON.parse(functionCall.arguments);
+      return typeof parsed === "object" && parsed !== null ? parsed : {};
+    } catch (error) {
+      throw new ToolExecutionError(
+        `Invalid JSON arguments for ${functionCall.name}: ${functionCall.arguments}`,
+        functionCall.name,
+        error instanceof Error ? error : undefined,
+      );
     }
   }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,7 @@
     "tabs",
     "tabGroups"
   ],
-  "{{firefox}}.permissions": ["activeTab", "storage", "scripting"],
+  "{{firefox}}.permissions": ["activeTab", "storage", "scripting", "tabs"],
   "host_permissions": ["<all_urls>"],
   "{{firefox}}.browser_specific_settings": {
     "gecko": {

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -64,6 +64,7 @@ const App: React.FC = () => {
     messages,
     addMessage,
     appendToLastMessage,
+    appendToolInteractions,
     completeLastMessage,
     clearCurrentGroupChat,
   } = useChatThread();
@@ -125,8 +126,6 @@ const App: React.FC = () => {
       addMessage(aiMessage);
       setInputValue(""); // Clear input field
 
-      const collectedInteractions: ToolInteraction[] = [];
-
       const contextToSend:
         { images?: ImageData[]; pageContent?: PageContent } | undefined =
         (images && images.length > 0) || pageContent
@@ -148,11 +147,11 @@ const App: React.FC = () => {
         },
         // onComplete: response completed
         () => {
-          completeLastMessage(collectedInteractions);
+          completeLastMessage();
         },
-        // onToolActivity: capture hidden execution context
+        // onToolActivity: log every tool call into the chat as it runs
         (interactions: ToolInteraction[]) => {
-          collectedInteractions.push(...interactions);
+          appendToolInteractions(interactions);
         },
       );
     },
@@ -160,6 +159,7 @@ const App: React.FC = () => {
       sendMessage,
       addMessage,
       appendToLastMessage,
+      appendToolInteractions,
       completeLastMessage,
       messages,
     ],

--- a/src/test/mocks/chrome.ts
+++ b/src/test/mocks/chrome.ts
@@ -16,6 +16,7 @@ interface Tab {
   active?: boolean;
   currentWindow?: boolean;
   groupId?: number;
+  status?: string;
 }
 
 interface RuntimeMessage {
@@ -48,6 +49,8 @@ interface ChromeMock {
       active?: boolean;
       currentWindow?: boolean;
     }) => Promise<Tab[]>;
+    get: (tabId: number) => Promise<Tab>;
+    update: (tabId: number, properties: { url?: string }) => Promise<Tab>;
     captureVisibleTab: (
       windowId?: number,
       options?: any,
@@ -136,6 +139,7 @@ const mockTabs: Tab[] = [
     active: true,
     currentWindow: true,
     groupId: -1,
+    status: "complete",
   },
 ];
 
@@ -162,6 +166,8 @@ const chromeMock: ChromeMock = {
   },
   tabs: {
     query: vi.fn().mockResolvedValue(mockTabs),
+    get: vi.fn().mockResolvedValue(mockTabs[0]),
+    update: vi.fn().mockResolvedValue(mockTabs[0]),
     captureVisibleTab: vi
       .fn()
       .mockImplementation((windowId, options, callback) => {


### PR DESCRIPTION
Emerald can now operate the browser on its own. The model gets six function
tools that read and act on the tab the side panel is attached to, and every call
it makes is written into the chat log.

## No headless browser

The extension already runs inside the browser it drives, so there is no
Playwright or Puppeteer dependency and no second browser process: the commands
execute in the content script of the page under control. That is faster than a
remote driver and works on pages the user is already signed in to. The trade-off
is that pages without a content script (`chrome://`, `about:`, the extension
gallery) cannot be driven — the tools say so instead of failing silently.

## Tools

| Tool | Purpose |
| --- | --- |
| `browser_read_page` | Title, URL and an indented outline of the visible DOM |
| `browser_list_elements` | Indexed list of links, buttons and form controls |
| `browser_click` | Click by index or CSS selector |
| `browser_fill` | Fill inputs, textareas, selects, checkboxes, contenteditable |
| `browser_navigate` | Open a URL and wait for the load to finish |
| `browser_scroll` | Move by viewport, jump to top or bottom, reveal an element |

They are registered in `AVAILABLE_TOOLS`, so `ToolExecutor` dispatches them like
any other function tool and no confirmation is asked for.

## How it works

- `src/lib/tools/browser-tools.ts` declares the tools and turns model arguments
  into commands.
- `src/lib/browser-agent/types.ts` is the command contract shared by both sides.
- `src/lib/browser-agent/bridge.ts` finds the active tab, relays commands and
  waits for navigations.
- `src/content/browser-agent.ts` executes the commands against the real DOM.

Commands answer with plain text, already formatted for the model.

**Reading the DOM.** Raw HTML is mostly noise, so `browser_read_page` emits one
line per element, indented by depth, carrying the useful attributes and the
element's own text. Meaningless elements (`script`, `style`, `svg`, …) and
CSS-hidden elements are skipped, attribute values are shortened, and the output
is capped at 12000 characters by default.

**Element indices.** `browser_list_elements` rebuilds a registry of the visible
interactive elements and hands out an index per element, which spares the model
from inventing selectors for markup it cannot see. A page load discards the
registry; a stale or detached index produces an error telling the model to list
again. Each line also carries a CSS selector, which the tools accept as an
alternative and which survives a reload.

**Navigation.** A click or a submit can destroy the content script before it
answers, so commands are answered synchronously and a lost response is treated
as a navigation rather than an error. Either way the bridge waits for the tab to
load and appends where the page ended up.

## Logging

`OpenAIClient` already reported executed calls through `onToolActivity`, but
nothing rendered them. They are now appended to the streaming message as they
run and shown by the new `ToolActivityLog` under a collapsible chip inside the
assistant bubble, arguments and returned text included, so an autonomous run can
be audited afterwards.

## Other changes

- `tabs` permission added for Firefox (Chrome already had it).
- Default system prompt describes the browser tools and the list-then-act loop.
- Docs: new `docs/architecture/browser-agent.md`, plus README and overview updates.

## Testing

- 52 new tests: DOM commands in jsdom, tool dispatch and navigation handling,
  executor routing, and the chat log component.
- `pnpm test` — 220 tests pass.
- `tsc --noEmit` clean; `pnpm build` succeeds for both Chrome and Firefox.